### PR TITLE
revert: renamed callApi to callApi_ for compatibility v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.1] - 2024-03-10
+
+### Changed
+
+* revert: renamed method direct DioExceptionHandler.callApi to DioExceptionHandler.callApi_ for compatibility v1 because method original use DioExceptionHandler().callApi()
+
 ## [2.0.0] - 2024-03-10
 
 ### Breaking Changes
@@ -26,7 +32,7 @@ Refactor of Exception Handling: The conversion of DioExceptionHandler into a mix
 
   ```dart
     final ResultState<UserModel> result =
-      await DioExceptionHandler.callApi<Response, UserModel>( // use direct call DioExceptionHandler.callApi
+      await DioExceptionHandler.callApi_<Response, UserModel>( // use direct call DioExceptionHandler.callApi
         ApiHandler(
           apiCall: () =>
               dio.get('https://jsonplaceholder.typicode.com/users/$id'),

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Future<void> fetchUserData() async {
         parserModel: (data) => UserModel.fromJson(data),
     );
 
-    ResultState<UserModel> result = await DioExceptionHandler.callApi(apiHandler);
+    // ResultState<UserModel> result = await DioExceptionHandler().callApi(apiHandler); // v1.x.x
+    ResultState<UserModel> result = await DioExceptionHandler.callApi_(apiHandler);
 
     switch (result) {
       case SuccessState<UserModel>(:UserModel data):
@@ -124,7 +125,8 @@ Future<void> fetchComplexData() async {
         parserModel: customParser,
     );
 
-    ResultState<ComplexData> result = await DioExceptionHandler.callApi(apiHandler);
+    // ResultState<ComplexData> result = await DioExceptionHandler().callApi(apiHandler); // v1.x.x
+    ResultState<ComplexData> result = await DioExceptionHandler.callApi_(apiHandler);
 
     switch (result) {
       case SuccessState<ComplexData>(:ComplexData data):
@@ -146,7 +148,8 @@ Handling basic exceptions with logging information:
 
 ```dart
 void handleApiCall() async {
-    ResultState<UserModel> result = await DioExceptionHandler.callApi(apiHandler);
+    // ResultState<UserModel> result = await DioExceptionHandler().callApi(apiHandler); // v1.x.x
+    ResultState<UserModel> result = await DioExceptionHandler.callApi_(apiHandler);
 
     switch (result) {
       case SuccessState<UserModel>(:UserModel data):
@@ -164,7 +167,8 @@ Implementing detailed handling for each type of exception:
 
 ```dart
 void advancedExceptionHandling() async {
-    ResultState<UserModel> result = await DioExceptionHandler.callApi(apiHandler);
+    // ResultState<UserModel> result = await DioExceptionHandler().callApi(apiHandler); // v1.x.x
+    ResultState<UserModel> result = await DioExceptionHandler.callApi_(apiHandler);
 
     switch (result) {
       case SuccessState<UserModel>(:UserModel data):

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -219,7 +219,7 @@ class UserService {
   final Dio dio = Dio();
   Future<ResultState<UserModel>> getDataUser(int id) async {
     final ResultState<UserModel> result =
-        await DioExceptionHandler.callApi<Response, UserModel>(
+        await DioExceptionHandler.callApi_<Response, UserModel>(
       ApiHandler(
         apiCall: () =>
             dio.get('https://jsonplaceholder.typicode.com/users/$id'),

--- a/lib/src/exception_handler/dio/dio_http_response_extension.dart
+++ b/lib/src/exception_handler/dio/dio_http_response_extension.dart
@@ -89,7 +89,7 @@ extension HttpResponseDioExtension on Future<Response<Object?>> {
   Future<ResultState<TModel>> fromJson<TModel>(
     TModel Function(Map<String, dynamic>) fromJson,
   ) async =>
-      await DioExceptionHandler.callApi<Response<Object?>, TModel>(
+      await DioExceptionHandler.callApi_<Response<Object?>, TModel>(
         ApiHandler(
           apiCall: () => this, // Same: response = dio.get('https://').
           parserModel: (Object? data) => fromJson(data as Map<String, dynamic>),
@@ -175,7 +175,7 @@ extension HttpResponseDioExtension on Future<Response<Object?>> {
   Future<ResultState<List<TModel>>> fromJsonAsList<TModel>(
     TModel Function(Map<String, dynamic>) fromJson,
   ) async =>
-      await DioExceptionHandler.callApi<Response<Object?>, List<TModel>>(
+      await DioExceptionHandler.callApi_<Response<Object?>, List<TModel>>(
         ApiHandler(
           apiCall: () => this, // Same: response = dio.get('https://').
           parserModel: (Object? data) => (data as List<Map<String, dynamic>>)

--- a/lib/src/exception_handler/dio/exception_handler_dio.dart
+++ b/lib/src/exception_handler/dio/exception_handler_dio.dart
@@ -109,7 +109,7 @@ class DioExceptionHandler implements ClientExceptionHandler {
   /// Eg:
   /// ```dart
   /// final ResultState<UserModel> result =
-  ///        await DioExceptionHandler.callApi<Response, UserModel>(
+  ///        await DioExceptionHandler.callApi_<Response, UserModel>(
   ///      ApiHandler(
   ///        apiCall: () {
   ///          return dio.get('https://jsonplaceholder.typicode.com/users/$id');
@@ -122,7 +122,7 @@ class DioExceptionHandler implements ClientExceptionHandler {
   ///
   /// {@endtemplate}
   @override
-  Future<ResultState<TModel>> callApi_<TResponse, TModel>(
+  Future<ResultState<TModel>> callApi<TResponse, TModel>(
     ApiHandler<TResponse, TModel> apiHandler, {
     HandleHttpParseResponse<TResponse, TModel>? handleHttpParseResponse,
   }) async {
@@ -166,11 +166,11 @@ class DioExceptionHandler implements ClientExceptionHandler {
   }
 
   /// {@macro DioExceptionHandler_callApi_}
-  static Future<ResultState<TModel>> callApi<TResponse, TModel>(
+  static Future<ResultState<TModel>> callApi_<TResponse, TModel>(
     ApiHandler<TResponse, TModel> apiHandler, {
     HandleHttpParseResponse<TResponse, TModel>? handleHttpParseResponse,
   }) async =>
-      DioExceptionHandler().callApi_(
+      DioExceptionHandler().callApi(
         apiHandler,
         handleHttpParseResponse: handleHttpParseResponse,
       );

--- a/lib/src/exception_handler/exception_handler_client.dart
+++ b/lib/src/exception_handler/exception_handler_client.dart
@@ -15,7 +15,7 @@ abstract class ClientExceptionHandler {
   /// Method [callApi] is a generic method to handle API calls and return a tuple of
   /// ExceptionState and parsed data.
   ///
-  Future<ResultState<TModel>> callApi_<R, TModel>(
+  Future<ResultState<TModel>> callApi<R, TModel>(
     ApiHandler<R, TModel> apiHandler, {
     HandleHttpParseResponse<R, TModel>? handleHttpParseResponse,
   });
@@ -23,7 +23,7 @@ abstract class ClientExceptionHandler {
   /// Method [callApi] is a generic method to handle API calls and return a tuple of
   /// ExceptionState and parsed data.
   ///
-  static Future<ResultState<TModel>> callApi<R, TModel>(
+  static Future<ResultState<TModel>> callApi_<R, TModel>(
     ApiHandler<R, TModel> apiHandler, {
     HandleHttpParseResponse<R, TModel>? handleHttpParseResponse,
   }) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: exception_handler
 description: A Dart package for streamlined API handling and robust exception management in Flutter apps.
-version: 2.0.0
+version: 2.0.1
 homepage: "https://github.com/andgar2010/exception_handler"
 
 environment:

--- a/test/src/exception_handler/dio/exception_handler_dio_test.dart
+++ b/test/src/exception_handler/dio/exception_handler_dio_test.dart
@@ -36,7 +36,7 @@ void main() {
             ),
           );
 
-          final ResultState<String> result = await DioExceptionHandler.callApi(
+          final ResultState<String> result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (Object? data) => (data as Map)['key'] as String,
@@ -67,7 +67,7 @@ void main() {
             ),
           );
 
-          final result = await DioExceptionHandler.callApi(
+          final result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (Object? data) => data as String,
@@ -101,7 +101,7 @@ void main() {
           when(() => mockConnectivity.checkConnectivity())
               .thenAnswer((_) async => ConnectivityResult.none);
 
-          final result = await DioExceptionHandler.callApi(mockApiHandler);
+          final result = await DioExceptionHandler.callApi_(mockApiHandler);
 
           expect(result, isA<FailureState<Object?>>());
 
@@ -119,7 +119,7 @@ void main() {
           when(() => mockDio.get<Object>(any()))
               .thenThrow(Exception('Client Error'));
 
-          final result = await DioExceptionHandler.callApi(
+          final result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (Object? data) => data as String,
@@ -152,7 +152,7 @@ void main() {
             ),
           );
 
-          final ResultState<String> result = await DioExceptionHandler.callApi(
+          final ResultState<String> result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (Object? data) => int.parse(data as String)
@@ -177,7 +177,8 @@ void main() {
       test(
         'should return FailureState with DataHttpException for 3xx error',
         () async {
-          final ResultState<Object?> result = await DioExceptionHandler.callApi(
+          final ResultState<Object?> result =
+              await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () async => Response<Object>(
                 requestOptions: RequestOptions(path: ''),
@@ -210,7 +211,8 @@ void main() {
               statusCode: 400,
             ),
           );
-          final ResultState<Object?> result = await DioExceptionHandler.callApi(
+          final ResultState<Object?> result =
+              await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (res) => null,
@@ -242,7 +244,8 @@ void main() {
               statusCode: 404,
             ),
           );
-          final ResultState<Object?> result = await DioExceptionHandler.callApi(
+          final ResultState<Object?> result =
+              await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (res) => null,
@@ -275,7 +278,8 @@ void main() {
               statusCode: 500,
             ),
           );
-          final ResultState<Object?> result = await DioExceptionHandler.callApi(
+          final ResultState<Object?> result =
+              await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (res) => null,
@@ -306,7 +310,8 @@ void main() {
               statusCode: 501,
             ),
           );
-          final ResultState<Object?> result = await DioExceptionHandler.callApi(
+          final ResultState<Object?> result =
+              await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (res) => null,
@@ -338,7 +343,8 @@ void main() {
               statusCode: 600,
             ),
           );
-          final ResultState<Object?> result = await DioExceptionHandler.callApi(
+          final ResultState<Object?> result =
+              await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (res) => null,
@@ -383,7 +389,7 @@ void main() {
               .thenAnswer((_) async => ConnectivityResult.wifi);
 
           final ResultState<String> result =
-              await DioExceptionHandler.callApi(mockApiHandler);
+              await DioExceptionHandler.callApi_(mockApiHandler);
 
           expect(result, isA<FailureState<Object?>>());
 
@@ -413,7 +419,7 @@ void main() {
               .thenAnswer((_) async => ConnectivityResult.wifi);
 
           final ResultState<String> result =
-              await DioExceptionHandler.callApi(mockApiHandler);
+              await DioExceptionHandler.callApi_(mockApiHandler);
 
           expect(result, isA<FailureState<Object?>>());
 
@@ -443,7 +449,7 @@ void main() {
               .thenAnswer((_) async => ConnectivityResult.wifi);
 
           final ResultState<String> result =
-              await DioExceptionHandler.callApi(mockApiHandler);
+              await DioExceptionHandler.callApi_(mockApiHandler);
 
           expect(result, isA<FailureState<Object?>>());
 
@@ -477,7 +483,7 @@ void main() {
         () async {
           final exception = Exception('General error');
           when(() => mockApiHandler.apiCall()).thenThrow(exception);
-          final result = await DioExceptionHandler.callApi(mockApiHandler);
+          final result = await DioExceptionHandler.callApi_(mockApiHandler);
 
           expect(result, isA<FailureState<Object?>>());
           expect(
@@ -497,7 +503,7 @@ void main() {
             ),
           );
 
-          final ResultState<String> result = await DioExceptionHandler.callApi(
+          final ResultState<String> result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (Object? data) {

--- a/test/src/exception_handler/exception_handler_client_test.dart
+++ b/test/src/exception_handler/exception_handler_client_test.dart
@@ -8,7 +8,7 @@ void main() {
   test('Testing ClientExceptionHandler.callApi', () async {
     try {
       // Act
-      await ClientExceptionHandler.callApi(
+      await ClientExceptionHandler.callApi_(
         MockApiHandler<Response<Object>, UserModel>(),
       );
     } catch (e) {


### PR DESCRIPTION
Renamed the method 'callApi' to 'callApi_' across multiple files. This change was made in order to avoid naming conflicts and improve code readability. The affected files include main.dart, dio_http_response_extension.dart, exception_handler_dio.dart, exception_handler_client.dart and their respective test files.
