### PR TITLE
refactor: 4.0.0-alpha

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -34,10 +34,11 @@ linter:
     - always_declare_return_types
     - always_put_control_body_on_new_line # works against dartfmt
     - always_put_required_named_parameters_first
-    # - always_specify_types # More disbuting
+    # - always_specify_types # More disturbing
     - avoid_annotating_with_dynamic
     - avoid_bool_literals_in_conditional_expressions
-    # - avoid_catching_errors # tempory disabled because working validation
+    # - avoid_catching_errors # temporary disabled because working validation
+    # - avoid_catches_without_on_clauses
     - avoid_classes_with_only_static_members
     - avoid_double_and_int_checks
     - avoid_field_initializers_in_const_classes
@@ -48,7 +49,7 @@ linter:
     - avoid_private_typedef_functions
     - avoid_returning_this
     - avoid_setters_without_getters
-    # - avoid_types_on_closure_parameters # confilict always_specify_types
+    # - avoid_types_on_closure_parameters # conflict always_specify_types
     - avoid_unused_constructor_parameters
     - avoid_void_async
     - cascade_invocations
@@ -56,7 +57,7 @@ linter:
     - join_return_with_assignment
     - library_prefixes
     # - lines_longer_than_80_chars
-    # - omit_local_variable_types # confilict always_specify_types
+    - omit_local_variable_types # conflict always_specify_types
     - one_member_abstracts
     - only_throw_errors
     - package_api_docs

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -66,7 +66,7 @@ class UserModel extends CustomEquatable {
       };
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = <String, dynamic>{};
+    final data = <String, dynamic>{};
     data['id'] = id;
     data['name'] = name;
     data['username'] = username;
@@ -79,6 +79,7 @@ class UserModel extends CustomEquatable {
     if (company != null) {
       data['company'] = company!.toJson();
     }
+
     return data;
   }
 }
@@ -129,7 +130,7 @@ class Address extends CustomEquatable {
       };
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = <String, dynamic>{};
+    final data = <String, dynamic>{};
     data['street'] = street;
     data['suite'] = suite;
     data['city'] = city;
@@ -137,6 +138,7 @@ class Address extends CustomEquatable {
     if (geo != null) {
       data['geo'] = geo!.toJson();
     }
+
     return data;
   }
 }
@@ -150,7 +152,7 @@ class Geo extends CustomEquatable {
           'lat': String? lat,
           'lng': String? lng,
         }) {
-      final Geo geo = Geo(lat: lat, lng: lng);
+      final geo = Geo(lat: lat, lng: lng);
       return geo;
     } else {
       throw FormatException('Invalid JSON: $json');
@@ -167,9 +169,10 @@ class Geo extends CustomEquatable {
       };
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = <String, dynamic>{};
+    final data = <String, dynamic>{};
     data['lat'] = lat;
     data['lng'] = lng;
+
     return data;
   }
 }
@@ -206,10 +209,11 @@ class Company extends CustomEquatable {
       };
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = <String, dynamic>{};
+    final data = <String, dynamic>{};
     data['name'] = name;
     data['catchPhrase'] = catchPhrase;
     data['bs'] = bs;
+
     return data;
   }
 }
@@ -218,8 +222,7 @@ class Company extends CustomEquatable {
 class UserService {
   final Dio dio = Dio();
   Future<Result<UserModel>> getDataUser(int id) async {
-    final Result<UserModel> result =
-        await DioExceptionHandler.callApi_<Response, UserModel>(
+    final result = await DioExceptionHandler.callApi_<Response, UserModel>(
       ApiHandler(
         apiCall: () =>
             dio.get('https://jsonplaceholder.typicode.com/users/$id'),
@@ -227,11 +230,12 @@ class UserService {
             UserModel.fromJson(data as Map<String, dynamic>),
       ),
     );
+
     return result;
   }
 
   Future<Result<UserModel>> getDataUserExtensionDio(int id) async {
-    final Result<UserModel> result = await dio
+    final result = await dio
         .get('https://jsonplaceholder.typicode.com/users/$id')
         .fromJson(UserModel.fromJson);
 
@@ -260,7 +264,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
+  const MyHomePage({required this.title, super.key});
 
   final String title;
 
@@ -313,13 +317,14 @@ class _MyHomePageState extends State<MyHomePage> {
                   if (snapshot.connectionState == ConnectionState.waiting) {
                     return const CircularProgressIndicator();
                   }
-                  final Result<UserModel> result = snapshot.requireData;
+                  final result = snapshot.requireData;
 
-                  final StatelessWidget uiWidget = switch (result) {
+                  final uiWidget = switch (result) {
                     Ok<UserModel> success => UiUserWidget(success.value),
                     Error<UserModel> failure =>
                       UiExceptionWidget(failure.error),
                   };
+
                   return uiWidget;
                 },
               ),
@@ -362,27 +367,23 @@ class UiExceptionWidget extends StatelessWidget {
     'https://httpcats.com',
   ];
 
-  final ExceptionState<UserModel> exception;
+  final Exception exception;
 
   @override
   Widget build(BuildContext context) {
-    final String textException = switch (exception) {
-      DataClientExceptionState<UserModel>() =>
-        'Debugger Error Client: $exception',
-      DataParseExceptionState<UserModel>() =>
-        'Debugger Error Parse: $exception',
-      DataHttpExceptionState<UserModel>() => 'Debugger Error Http: $exception',
-      DataNetworkExceptionState<UserModel>() =>
+    final textException = switch (exception) {
+      DataClientException() => 'Debugger Error Client: $exception',
+      DataParseException() => 'Debugger Error Parse: $exception',
+      DataHttpException() => 'Debugger Error Http: $exception',
+      DataNetworkException() =>
         'Debugger Error Network: $exception\n\nError: ${exception.toString().split('.').last}',
-      DataCacheExceptionState<UserModel>() =>
-        'Debugger Error Cache: $exception',
-      DataInvalidInputExceptionState<UserModel>() =>
-        'Debugger Error Invalid Input: $exception',
-      DataUnknownExceptionState<UserModel>() =>
-        'Debugger Error Unknown: $exception',
+      DataCacheException() => 'Debugger Error Cache: $exception',
+      DataInvalidInputException() => 'Debugger Error Invalid Input: $exception',
+      DataUnknownException() => 'Debugger Error Unknown: $exception',
+      _ => 'Debugger Error Unknown: $exception',
     };
 
-    final Text text = Text(
+    final text = Text(
       textException,
       style: TextStyle(color: Colors.orange[800]),
     );
@@ -391,23 +392,20 @@ class UiExceptionWidget extends StatelessWidget {
       ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: text));
     });
 
-    final Widget imageException = switch (exception) {
-      DataClientExceptionState<UserModel>() =>
-        const Icon(Icons.devices_outlined, size: 200),
-      DataParseExceptionState<UserModel>() =>
-        const Icon(Icons.sms_failed_outlined, size: 200),
-      DataHttpExceptionState<UserModel>() => Image.network(
+    final imageException = switch (exception) {
+      DataClientException() => const Icon(Icons.devices_outlined, size: 200),
+      DataParseException() => const Icon(Icons.sms_failed_outlined, size: 200),
+      DataHttpException() => Image.network(
           '${links[Random().nextInt(links.length)]}/404.webp',
         ),
-      DataNetworkExceptionState<UserModel>() =>
-        const Icon(Icons.wifi_off_outlined, size: 200),
-      DataCacheExceptionState<UserModel>() =>
-        const Icon(Icons.storage_outlined, size: 200),
-      DataInvalidInputExceptionState<UserModel>() =>
+      DataNetworkException() => const Icon(Icons.wifi_off_outlined, size: 200),
+      DataCacheException() => const Icon(Icons.storage_outlined, size: 200),
+      DataInvalidInputException() =>
         const Icon(Icons.textsms_outlined, size: 200),
-      DataUnknownExceptionState<UserModel>() =>
-        const Icon(Icons.close, size: 200),
+      DataUnknownException() => const Icon(Icons.close, size: 200),
+      _ => const Icon(Icons.close, size: 200),
     };
+
     return Column(
       children: [
         SizedBox(
@@ -431,7 +429,7 @@ class UiUserWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final TextTheme textTheme = Theme.of(context).textTheme;
+    final textTheme = Theme.of(context).textTheme;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -313,12 +313,10 @@ class _MyHomePageState extends State<MyHomePage> {
                   if (snapshot.connectionState == ConnectionState.waiting) {
                     return const CircularProgressIndicator();
                   }
-                  final Result<UserModel> result =
-                      snapshot.requireData;
+                  final Result<UserModel> result = snapshot.requireData;
 
                   final StatelessWidget uiWidget = switch (result) {
-                    Ok<UserModel> success =>
-                      UiUserWidget(success.value),
+                    Ok<UserModel> success => UiUserWidget(success.value),
                     Error<UserModel> failure =>
                       UiExceptionWidget(failure.error),
                   };

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -217,8 +217,8 @@ class Company extends CustomEquatable {
 // Path: services/user_service.dart
 class UserService {
   final Dio dio = Dio();
-  Future<ResultState<UserModel>> getDataUser(int id) async {
-    final ResultState<UserModel> result =
+  Future<Result<UserModel>> getDataUser(int id) async {
+    final Result<UserModel> result =
         await DioExceptionHandler.callApi_<Response, UserModel>(
       ApiHandler(
         apiCall: () =>
@@ -230,8 +230,8 @@ class UserService {
     return result;
   }
 
-  Future<ResultState<UserModel>> getDataUserExtensionDio(int id) async {
-    final ResultState<UserModel> result = await dio
+  Future<Result<UserModel>> getDataUserExtensionDio(int id) async {
+    final Result<UserModel> result = await dio
         .get('https://jsonplaceholder.typicode.com/users/$id')
         .fromJson(UserModel.fromJson);
 
@@ -308,19 +308,19 @@ class _MyHomePageState extends State<MyHomePage> {
                 future: UserService().getDataUserExtensionDio(_counter),
                 builder: (
                   BuildContext context,
-                  AsyncSnapshot<ResultState<UserModel>> snapshot,
+                  AsyncSnapshot<Result<UserModel>> snapshot,
                 ) {
                   if (snapshot.connectionState == ConnectionState.waiting) {
                     return const CircularProgressIndicator();
                   }
-                  final ResultState<UserModel> resultState =
+                  final Result<UserModel> result =
                       snapshot.requireData;
 
-                  final StatelessWidget uiWidget = switch (resultState) {
-                    SuccessState<UserModel> success =>
-                      UiUserWidget(success.data),
-                    FailureState<UserModel> failure =>
-                      UiExceptionWidget(failure.exception),
+                  final StatelessWidget uiWidget = switch (result) {
+                    Ok<UserModel> success =>
+                      UiUserWidget(success.value),
+                    Error<UserModel> failure =>
+                      UiExceptionWidget(failure.error),
                   };
                   return uiWidget;
                 },

--- a/lib/src/exception_handler/client_exception_handler.dart
+++ b/lib/src/exception_handler/client_exception_handler.dart
@@ -15,17 +15,17 @@ abstract class ClientExceptionHandler {
   /// Method [callApi] is a generic method to handle API calls and return a tuple of
   /// ExceptionState and parsed data.
   ///
-  Future<ResultState<TModel>> callApi<R, TModel>(
-    final ApiHandler<R, TModel> apiHandler, {
-    final HandleHttpParseResponse<R, TModel>? handleHttpParseResponse,
+  Future<Result<T>> callApi<R, T>(
+    final ApiHandler<R, T> apiHandler, {
+    final HandleHttpParseResponse<R, T>? handleHttpParseResponse,
   });
 
   /// Method [callApi] is a generic method to handle API calls and return a tuple of
   /// ExceptionState and parsed data.
   ///
-  static Future<ResultState<TModel>> callApi_<R, TModel>(
-    final ApiHandler<R, TModel> apiHandler, {
-    final HandleHttpParseResponse<R, TModel>? handleHttpParseResponse,
+  static Future<Result<T>> callApi_<R, T>(
+    final ApiHandler<R, T> apiHandler, {
+    final HandleHttpParseResponse<R, T>? handleHttpParseResponse,
   }) async {
     throw UnimplementedError();
   }

--- a/lib/src/exception_handler/dio/dio_exception_handler.dart
+++ b/lib/src/exception_handler/dio/dio_exception_handler.dart
@@ -16,21 +16,21 @@ import '../../../exception_handler.dart';
 /// Method [handleHttpGenericParseResponseDio] tries to parse the response and handle
 /// any parsing exceptions.
 ///
-Future<ResultState<TModel>> handleHttpGenericParseResponseDio<Response, TModel>(
+Future<Result<T>> handleHttpGenericParseResponseDio<Response, T>(
   final int statusCode,
-  final ResponseParser<Response, TModel> responseParser,
+  final ResponseParser<Response, T> responseParser,
 ) async {
   try {
-    return FailureState(
-      DataHttpExceptionState<TModel>(
+    return Error(
+      DataHttpExceptionState<T>(
         message: responseParser.exception.toString(),
         httpException: HttpStatus.fromCode(statusCode).exception(),
         stackTrace: StackTrace.current,
       ),
     );
   } catch (e) {
-    return FailureState(
-      DataHttpExceptionState<TModel>(
+    return Error(
+      DataHttpExceptionState<T>(
         message: responseParser.exception.toString(),
         httpException: HttpException(
           httpStatus: HttpStatus(
@@ -48,16 +48,16 @@ Future<ResultState<TModel>> handleHttpGenericParseResponseDio<Response, TModel>(
 
 /// Method [handleHttp2xxParseResponseDio] tries to parse the response and handle
 /// any parsing exceptions.
-Future<ResultState<TModel>> handleHttp2xxParseResponseDio<TModel>(
-  final ResponseParser<Response<Object?>, TModel> responseParser,
+Future<Result<T>> handleHttp2xxParseResponseDio<T>(
+  final ResponseParser<Response<Object?>, T> responseParser,
 ) async {
   try {
-    final TModel dataModelParsed = await compute(
+    final T dataModelParsed = await compute(
       responseParser.parserModel,
       responseParser.response.data,
     );
 
-    return SuccessState(dataModelParsed);
+    return Ok(dataModelParsed);
   } catch (e) {
     try {
       // TODO(andgar2010): need more investigation about compute error on platform windows.
@@ -69,27 +69,27 @@ Change mode async isolate to sync''',
         name: 'DioExceptionHandler._handle2xxparseResponse',
       );
 
-      final TModel dataModelParsed =
+      final T dataModelParsed =
           responseParser.parserModel(responseParser.response.data);
 
-      return SuccessState(dataModelParsed);
+      return Ok(dataModelParsed);
     } on FormatException catch (e, s) {
-      return FailureState(
-        DataParseExceptionState<TModel>(
+      return Error(
+        DataParseExceptionState<T>(
           message: e.toString(),
           stackTrace: s,
         ),
       );
     } on TypeError catch (e, s) {
-      return FailureState(
-        DataParseExceptionState<TModel>(
+      return Error(
+        DataParseExceptionState<T>(
           message: e.toString(),
           stackTrace: s,
         ),
       );
     } catch (e, s) {
-      return FailureState(
-        DataUnknownExceptionState<TModel>(
+      return Error(
+        DataUnknownExceptionState<T>(
           message: e.toString().replaceAll('Exception: ', ''),
           stackTrace: s,
         ),
@@ -109,7 +109,7 @@ class DioExceptionHandler implements ClientExceptionHandler {
   ///
   /// Eg:
   /// ```dart
-  /// final ResultState<UserModel> result =
+  /// final Result<UserModel> result =
   ///        await DioExceptionHandler.callApi_<Response, UserModel>(
   ///      ApiHandler(
   ///        apiCall: () {
@@ -123,12 +123,12 @@ class DioExceptionHandler implements ClientExceptionHandler {
   ///
   /// {@endtemplate}
   @override
-  Future<ResultState<TModel>> callApi<TResponse, TModel>(
-    final ApiHandler<TResponse, TModel> apiHandler, {
-    final HandleHttpParseResponse<TResponse, TModel>? handleHttpParseResponse,
+  Future<Result<T>> callApi<TResponse, T>(
+    final ApiHandler<TResponse, T> apiHandler, {
+    final HandleHttpParseResponse<TResponse, T>? handleHttpParseResponse,
   }) async {
     handleParseResponse_ = handleHttpParseResponse ??
-        HandleHttpParseResponse<Response<Object?>, TModel>(
+        HandleHttpParseResponse<Response<Object?>, T>(
           handleHttp1xxParseResponse: handleHttpGenericParseResponseDio,
           // TODO(andgar2010): investigation bug.
           // handleHttp2xxParseResponse: handleHttp2xxParseResponseDio,
@@ -150,8 +150,8 @@ class DioExceptionHandler implements ClientExceptionHandler {
       );
     } on DioException catch (e, s) {
       if (!await _isConnected() || e.type == DioExceptionType.connectionError) {
-        return FailureState(
-          DataNetworkExceptionState<TModel>(
+        return Error(
+          DataNetworkExceptionState<T>(
             message: 'NetworkException.noInternetConnection',
             stackTrace: s,
           ),
@@ -160,16 +160,16 @@ class DioExceptionHandler implements ClientExceptionHandler {
 
       return await _handleDioException(e, s);
     } on Exception catch (e, s) {
-      return FailureState(
-        DataClientExceptionState<TModel>(message: e.toString(), stackTrace: s),
+      return Error(
+        DataClientExceptionState<T>(message: e.toString(), stackTrace: s),
       );
     }
   }
 
   /// {@macro DioExceptionHandler_callApi_}
-  static Future<ResultState<TModel>> callApi_<TResponse, TModel>(
-    final ApiHandler<TResponse, TModel> apiHandler, {
-    final HandleHttpParseResponse<TResponse, TModel>? handleHttpParseResponse,
+  static Future<Result<T>> callApi_<TResponse, T>(
+    final ApiHandler<TResponse, T> apiHandler, {
+    final HandleHttpParseResponse<TResponse, T>? handleHttpParseResponse,
   }) =>
       DioExceptionHandler().callApi(
         apiHandler,
@@ -186,17 +186,17 @@ class DioExceptionHandler implements ClientExceptionHandler {
 
   /// _handleHttpResponse processes the HTTP response and handles different
   /// status codes.
-  static Future<ResultState<TModel>> _handleHttpResponse<TModel>(
-    final ResponseParser<Response<Object?>, TModel> responseParser,
+  static Future<Result<T>> _handleHttpResponse<T>(
+    final ResponseParser<Response<Object?>, T> responseParser,
   ) async {
     final int? statusCode = responseParser.response.statusCode;
 
     return await _handleStatusCode(statusCode, responseParser);
   }
 
-  static Future<ResultState<TModel>> _handleStatusCode<TModel>(
+  static Future<Result<T>> _handleStatusCode<T>(
     final int? statusCode,
-    final ResponseParser<Response<Object?>, TModel> responseParser,
+    final ResponseParser<Response<Object?>, T> responseParser,
   ) async =>
       // coverage:ignore-start
       switch (statusCode) {
@@ -207,7 +207,7 @@ class DioExceptionHandler implements ClientExceptionHandler {
             responseParser,
           ),
         final int statusCode when statusCode.isSuccessfulHttpStatusCode =>
-          await handleHttp2xxParseResponseDio<TModel>(responseParser),
+          await handleHttp2xxParseResponseDio<T>(responseParser),
         // TODO(andgar2010): investigation bug
         // final int statusCode when statusCode.isSuccessfulHttpStatusCode =>
         //   await handleParseResponse_.handleHttp2xxParseResponse!(responseParser),
@@ -234,7 +234,7 @@ class DioExceptionHandler implements ClientExceptionHandler {
 
   /// _handleDioException handles exceptions from the Dio library,
   /// particularly around connectivity.
-  static Future<ResultState<TModel>> _handleDioException<TModel>(
+  static Future<Result<T>> _handleDioException<T>(
     final DioException e,
     final StackTrace s,
   ) async {
@@ -246,12 +246,12 @@ class DioExceptionHandler implements ClientExceptionHandler {
         int.tryParse(e.message.toString().split(start).last.split(end).first) ??
             e.response?.statusCode;
 
-    late final Future<ResultState<TModel>> handleStatusCode = _handleStatusCode(
+    late final Future<Result<T>> handleStatusCode = _handleStatusCode(
       statusCode,
       ResponseParser(
         response: Response(requestOptions: RequestOptions()),
         // coverage:ignore-start
-        parserModel: (final _) => Object() as TModel,
+        parserModel: (final _) => Object() as T,
         // coverage:ignore-end
         exception: e,
         stackTrace: s,
@@ -261,26 +261,26 @@ class DioExceptionHandler implements ClientExceptionHandler {
     return statusCode != null
         ? await handleStatusCode
         : switch (e.type) {
-            DioExceptionType.connectionTimeout => FailureState(
-                DataNetworkExceptionState<TModel>(
+            DioExceptionType.connectionTimeout => Error(
+                DataNetworkExceptionState<T>(
                   message: 'NetworkException.timeOutException',
                   stackTrace: s,
                 ),
               ),
-            DioExceptionType.receiveTimeout => FailureState(
-                DataNetworkExceptionState<TModel>(
+            DioExceptionType.receiveTimeout => Error(
+                DataNetworkExceptionState<T>(
                   message: 'NetworkException.receiveTimeout',
                   stackTrace: s,
                 ),
               ),
-            DioExceptionType.cancel => FailureState(
-                DataNetworkExceptionState<TModel>(
+            DioExceptionType.cancel => Error(
+                DataNetworkExceptionState<T>(
                   message: 'NetworkException.cancel',
                   stackTrace: s,
                 ),
               ),
-            DioExceptionType.sendTimeout => FailureState(
-                DataNetworkExceptionState<TModel>(
+            DioExceptionType.sendTimeout => Error(
+                DataNetworkExceptionState<T>(
                   message: 'NetworkException.sendTimeout',
                   stackTrace: s,
                 ),

--- a/lib/src/exception_handler/dio/dio_exception_handler.dart
+++ b/lib/src/exception_handler/dio/dio_exception_handler.dart
@@ -52,7 +52,7 @@ Future<Result<T>> handleHttp2xxParseResponseDio<T>(
   final ResponseParser<Response<Object?>, T> responseParser,
 ) async {
   try {
-    final T dataModelParsed = await compute(
+    final dataModelParsed = await compute(
       responseParser.parserModel,
       responseParser.response.data,
     );
@@ -69,7 +69,7 @@ Change mode async isolate to sync''',
         name: 'DioExceptionHandler._handle2xxparseResponse',
       );
 
-      final T dataModelParsed =
+      final dataModelParsed =
           responseParser.parserModel(responseParser.response.data);
 
       return Ok(dataModelParsed);
@@ -139,8 +139,7 @@ class DioExceptionHandler implements ClientExceptionHandler {
         );
 
     try {
-      final Response<Object?> response =
-          await apiHandler.apiCall() as Response<Object?>;
+      final response = await apiHandler.apiCall() as Response<Object?>;
 
       return _handleHttpResponse(
         ResponseParser(
@@ -178,8 +177,7 @@ class DioExceptionHandler implements ClientExceptionHandler {
 
   /// _isConnected checks the current network connectivity status.
   static Future<bool> _isConnected() async {
-    final List<ConnectivityResult> result =
-        await connectivity.checkConnectivity();
+    final result = await connectivity.checkConnectivity();
 
     return !result.contains(ConnectivityResult.none);
   }
@@ -189,7 +187,7 @@ class DioExceptionHandler implements ClientExceptionHandler {
   static Future<Result<T>> _handleHttpResponse<T>(
     final ResponseParser<Response<Object?>, T> responseParser,
   ) async {
-    final int? statusCode = responseParser.response.statusCode;
+    final statusCode = responseParser.response.statusCode;
 
     return await _handleStatusCode(statusCode, responseParser);
   }
@@ -238,15 +236,15 @@ class DioExceptionHandler implements ClientExceptionHandler {
     final DioException e,
     final StackTrace s,
   ) async {
-    const String start =
+    const start =
         'This exception was thrown because the response has a status code of ';
-    const String end =
+    const end =
         'and RequestOptions.validateStatus was configured to throw for this status code.';
-    final int? statusCode =
+    final statusCode =
         int.tryParse(e.message.toString().split(start).last.split(end).first) ??
             e.response?.statusCode;
 
-    late final Future<Result<T>> handleStatusCode = _handleStatusCode(
+    late final handleStatusCode = _handleStatusCode(
       statusCode,
       ResponseParser(
         response: Response(requestOptions: RequestOptions()),

--- a/lib/src/exception_handler/dio/dio_http_response_extension.dart
+++ b/lib/src/exception_handler/dio/dio_http_response_extension.dart
@@ -7,9 +7,9 @@ import 'package:dio/dio.dart';
 import '../../../exception_handler.dart';
 
 /// An extension on `Future<Response>` providing methods for handling Dio HTTP responses and converting them
-/// into [ResultState<TModel>] or [ResultState<List<TModel>>] types.
+/// into [Result<T>] or [Result<List<T>>] types.
 extension DioHttpResponseExtension on Future<Response<Object?>> {
-  /// Converts a Dio HTTP response into an [ResultState<TModel>] type using
+  /// Converts a Dio HTTP response into an [Result<T>] type using
   /// a custom `fromJson` method.
   ///
   /// Usage:
@@ -86,10 +86,10 @@ extension DioHttpResponseExtension on Future<Response<Object?>> {
   ///    }
   /// ```
   ///
-  Future<ResultState<TModel>> fromJson<TModel>(
-    final TModel Function(Map<String, dynamic>) fromJson,
+  Future<Result<T>> fromJson<T>(
+    final T Function(Map<String, dynamic>) fromJson,
   ) async =>
-      await DioExceptionHandler.callApi_<Response<Object?>, TModel>(
+      await DioExceptionHandler.callApi_<Response<Object?>, T>(
         ApiHandler(
           apiCall: () => this, // Same: response = dio.get('https://').
           parserModel: (final Object? data) =>
@@ -97,7 +97,7 @@ extension DioHttpResponseExtension on Future<Response<Object?>> {
         ),
       );
 
-  /// Converts a Dio HTTP response into an [ResultState<List<TModel>>] type
+  /// Converts a Dio HTTP response into an [Result<List<T>>] type
   /// using a custom `fromJsonAsList` method.
   ///
   /// Usage:
@@ -173,10 +173,10 @@ extension DioHttpResponseExtension on Future<Response<Object?>> {
   ///        print(failure.exception);
   ///    }
   /// ```
-  Future<ResultState<List<TModel>>> fromJsonAsList<TModel>(
-    final TModel Function(Map<String, dynamic>) fromJson,
+  Future<Result<List<T>>> fromJsonAsList<T>(
+    final T Function(Map<String, dynamic>) fromJson,
   ) async =>
-      await DioExceptionHandler.callApi_<Response<Object?>, List<TModel>>(
+      await DioExceptionHandler.callApi_<Response<Object?>, List<T>>(
         ApiHandler(
           apiCall: () => this, // Same: response = dio.get('https://').
           parserModel: (final Object? data) =>

--- a/lib/src/exception_handler/typedef.dart
+++ b/lib/src/exception_handler/typedef.dart
@@ -4,17 +4,17 @@
 
 import '../src.dart';
 
-typedef ApiCall<R, TModel> = Future<R> Function();
-typedef ParseFunction<TModel> = TModel Function(Object?);
+typedef ApiCall<R, T> = Future<R> Function();
+typedef ParseFunction<T> = T Function(Object?);
 
-class ApiHandler<R, TModel> {
+class ApiHandler<R, T> {
   ApiHandler({required this.apiCall, required this.parserModel});
 
-  final ApiCall<R, TModel> apiCall;
-  final ParseFunction<TModel> parserModel;
+  final ApiCall<R, T> apiCall;
+  final ParseFunction<T> parserModel;
 }
 
-class ResponseParser<R, TModel> extends CustomEquatable {
+class ResponseParser<R, T> extends CustomEquatable {
   const ResponseParser({
     required this.response,
     required this.parserModel,
@@ -22,7 +22,7 @@ class ResponseParser<R, TModel> extends CustomEquatable {
     this.stackTrace,
   });
 
-  final ParseFunction<TModel> parserModel;
+  final ParseFunction<T> parserModel;
   final R response;
   final Exception? exception;
   final StackTrace? stackTrace;
@@ -36,7 +36,7 @@ class ResponseParser<R, TModel> extends CustomEquatable {
       };
 }
 
-class HandleHttpParseResponse<R, TModel> {
+class HandleHttpParseResponse<R, T> {
   HandleHttpParseResponse({
     this.handleHttp1xxParseResponse,
     // TODO(andgar2010): investigation bug.
@@ -47,33 +47,33 @@ class HandleHttpParseResponse<R, TModel> {
     this.handleHttpUnknownParseResponse,
   });
 
-  final Future<ResultState<TModel>> Function<R, TModel>(
+  final Future<Result<T>> Function<R, T>(
     int statusCode,
-    ResponseParser<R, TModel>,
+    ResponseParser<R, T>,
   )? handleHttp1xxParseResponse;
 
   // TODO(andgar2010): investigation bug.
-  // final Future<ResultState<TModel>> Function<TModel>(
+  // final Future<Result<T>> Function<T>(
   //   ResponseParser,
   // )? handleHttp2xxParseResponse;
 
-  final Future<ResultState<TModel>> Function<R, TModel>(
+  final Future<Result<T>> Function<R, T>(
     int statusCode,
-    ResponseParser<R, TModel>,
+    ResponseParser<R, T>,
   )? handleHttp3xxParseResponse;
 
-  final Future<ResultState<TModel>> Function<R, TModel>(
+  final Future<Result<T>> Function<R, T>(
     int statusCode,
-    ResponseParser<R, TModel>,
+    ResponseParser<R, T>,
   )? handleHttp4xxParseResponse;
 
-  final Future<ResultState<TModel>> Function<R, TModel>(
+  final Future<Result<T>> Function<R, T>(
     int statusCode,
-    ResponseParser<R, TModel>,
+    ResponseParser<R, T>,
   )? handleHttp5xxParseResponse;
 
-  final Future<ResultState<TModel>> Function<R, TModel>(
+  final Future<Result<T>> Function<R, T>(
     int statusCode,
-    ResponseParser<R, TModel>,
+    ResponseParser<R, T>,
   )? handleHttpUnknownParseResponse;
 }

--- a/lib/src/exception_state/exception_state.dart
+++ b/lib/src/exception_state/exception_state.dart
@@ -12,8 +12,7 @@ import '../utils/utils.dart';
 /// various exceptions.
 ///
 /// It includes optional fields for different exception types.
-sealed class ExceptionState<TModel> extends CustomEquatable
-    implements Exception {
+sealed class ExceptionState<T> extends CustomEquatable implements Exception {
   const ExceptionState({
     required this.message,
     required this.stackTrace,
@@ -22,15 +21,19 @@ sealed class ExceptionState<TModel> extends CustomEquatable
   /// A message describing the format error.
   final String message;
   final StackTrace stackTrace;
+
+  @override
+  Map<String, Object?> get namedProps =>
+      {'message': message, 'stackTrace': stackTrace};
 }
 
 /// [DataClientExceptionState] captures exceptions related to client-side
 /// issues.
 ///
 /// This exception class extends [ExceptionState], providing a generic type
-/// [TModel] to allow encapsulating additional information or data related to
+/// [T] to allow encapsulating additional information or data related to
 /// the exception.
-class DataClientExceptionState<TModel> extends ExceptionState<TModel> {
+class DataClientExceptionState<T> extends ExceptionState<T> {
   DataClientExceptionState({
     required final String message,
     required final StackTrace stackTrace,
@@ -52,9 +55,9 @@ class DataClientExceptionState<TModel> extends ExceptionState<TModel> {
 /// (e.g., JSON parsing).
 ///
 /// This exception class extends [ExceptionState], providing a generic type
-/// [TModel] to allow encapsulating additional information or data related to
+/// [T] to allow encapsulating additional information or data related to
 /// the exception.
-class DataParseExceptionState<TModel> extends ExceptionState<TModel> {
+class DataParseExceptionState<T> extends ExceptionState<T> {
   DataParseExceptionState({
     required final StackTrace stackTrace,
     final String message = 'Error parsing data.',
@@ -74,9 +77,9 @@ class DataParseExceptionState<TModel> extends ExceptionState<TModel> {
 /// [DataHttpExceptionState] is used for handling HTTP-related exceptions.
 ///
 /// This exception class extends [ExceptionState], providing a generic type
-/// [TModel] to allow encapsulating additional information or data related to
+/// [T] to allow encapsulating additional information or data related to
 /// the exception.
-class DataHttpExceptionState<TModel> extends ExceptionState<TModel> {
+class DataHttpExceptionState<T> extends ExceptionState<T> {
   DataHttpExceptionState({
     required this.httpException,
     required final StackTrace stackTrace,
@@ -104,9 +107,9 @@ class DataHttpExceptionState<TModel> extends ExceptionState<TModel> {
 /// (e.g., no internet connection).
 ///
 /// This exception class extends [ExceptionState], providing a generic type
-/// [TModel] to allow encapsulating additional information or data related to
+/// [T] to allow encapsulating additional information or data related to
 /// the exception.
-class DataNetworkExceptionState<TModel> extends ExceptionState<TModel> {
+class DataNetworkExceptionState<T> extends ExceptionState<T> {
   DataNetworkExceptionState({
     required final StackTrace stackTrace,
     final String message = 'A network error occurred.',
@@ -127,9 +130,9 @@ class DataNetworkExceptionState<TModel> extends ExceptionState<TModel> {
 /// caching operations.
 ///
 /// This exception class extends [ExceptionState], providing a generic type
-/// [TModel] to allow encapsulating additional information or data related to
+/// [T] to allow encapsulating additional information or data related to
 /// the exception.
-class DataCacheExceptionState<TModel> extends ExceptionState<TModel> {
+class DataCacheExceptionState<T> extends ExceptionState<T> {
   DataCacheExceptionState({
     required final StackTrace stackTrace,
     final String message = 'A cache error occurred.',
@@ -150,9 +153,9 @@ class DataCacheExceptionState<TModel> extends ExceptionState<TModel> {
 /// invalid input data.
 ///
 /// This exception class extends [ExceptionState], providing a generic type
-/// [TModel] to allow encapsulating additional information or data related to
+/// [T] to allow encapsulating additional information or data related to
 /// the exception.
-class DataInvalidInputExceptionState<TModel> extends ExceptionState<TModel> {
+class DataInvalidInputExceptionState<T> extends ExceptionState<T> {
   DataInvalidInputExceptionState({
     required final StackTrace stackTrace,
     final String message = 'Invalid input provided.',
@@ -173,9 +176,9 @@ class DataInvalidInputExceptionState<TModel> extends ExceptionState<TModel> {
 /// Unknown error data.
 ///
 /// This exception class extends [ExceptionState], providing a generic type
-/// [TModel] to allow encapsulating additional information or data related to
+/// [T] to allow encapsulating additional information or data related to
 /// the exception.
-class DataUnknownExceptionState<TModel> extends ExceptionState<TModel> {
+class DataUnknownExceptionState<T> extends ExceptionState<T> {
   DataUnknownExceptionState({
     required final String message,
     required final StackTrace stackTrace,

--- a/lib/src/result_state/result_state.dart
+++ b/lib/src/result_state/result_state.dart
@@ -5,6 +5,7 @@
 import '../exception_state/exception_state.dart';
 import '../utils/utils.dart';
 
+// coverage:ignore-start
 /// An sealed base ResultState class
 /// to [TModel] represents the different states of result.
 @Deprecated('Use class Result() instead.')
@@ -33,17 +34,31 @@ final class FailureState<TModel> extends ResultState<TModel> {
   @override
   Map<String, Object?> get namedProps => {'exception': exception};
 }
+// coverage:ignore-end
 
 /// Utility class that simplifies handling errors.
-/// Inspired by the [Result] class from the official Dart language documentation https://docs.flutter.dev/app-architecture/design-patterns/result.
 ///
-/// Return a [Result] from a function to indicate success or failure.
+/// Inspired by the [Result] class from the official Dart language documentation https://docs.flutter.dev/app-architecture/design-patterns/result#putting-it-all-together.
 ///
-/// A [Result] is either an [Ok] with a value of type [T]
-/// or an [Error] with an [Exception].
+/// Use this class to return a `Result` from a function, indicating success or failure.
 ///
-/// Use [Result.ok] to create a successful result with a value of type [T].
-/// Use [Result.error] to create an error result with an [Exception].
+/// A `Result` object can be either an `Ok` with a value of type `T`, or an `Error` with an `Exception`.
+///
+/// Use `Result.ok(value)` to create a successful result with a value of type `T`.
+/// Use `Result.error(exception)` to create an error result with an `Exception`.
+///
+/// Example:
+///
+/// /// A function that returns a `Result` object.
+/// ```dart
+/// Result<int> getResult() {
+///  try {
+///   // Some code that might throw an exception.
+///  return Result.ok(42);
+/// } catch (e) {
+///  return Result.error(Exception(e));
+/// }
+/// ```
 sealed class Result<T> extends CustomEquatable {
   const Result();
 
@@ -51,7 +66,7 @@ sealed class Result<T> extends CustomEquatable {
   factory Result.ok(final T value) => Ok(value);
 
   /// Create an instance of Result containing an error.
-  factory Result.error(final ExceptionState<T> error) => Error(error);
+  factory Result.error(final Exception error) => Error(error);
 }
 
 /// Subclass of Result for values.
@@ -70,7 +85,7 @@ final class Error<T> extends Result<T> {
   const Error(this.error);
 
   /// Returned error in result.
-  final ExceptionState<T> error;
+  final Exception error;
 
   @override
   Map<String, Object?> get namedProps => {'error': error};

--- a/lib/src/result_state/result_state.dart
+++ b/lib/src/result_state/result_state.dart
@@ -7,11 +7,13 @@ import '../utils/utils.dart';
 
 /// An sealed base ResultState class
 /// to [TModel] represents the different states of result.
+@Deprecated('Use class Result() instead.')
 sealed class ResultState<TModel> extends CustomEquatable {
   const ResultState();
 }
 
 /// Success status with a generic value [TModel].
+@Deprecated('Use class OK() instead.')
 final class SuccessState<TModel> extends ResultState<TModel> {
   const SuccessState(this.data);
 
@@ -22,6 +24,7 @@ final class SuccessState<TModel> extends ResultState<TModel> {
 }
 
 /// Error status with a specific type of exception.
+@Deprecated('Use class Error() instead.')
 final class FailureState<TModel> extends ResultState<TModel> {
   const FailureState(this.exception);
 
@@ -29,4 +32,46 @@ final class FailureState<TModel> extends ResultState<TModel> {
 
   @override
   Map<String, Object?> get namedProps => {'exception': exception};
+}
+
+/// Utility class that simplifies handling errors.
+/// Inspired by the [Result] class from the official Dart language documentation https://docs.flutter.dev/app-architecture/design-patterns/result.
+///
+/// Return a [Result] from a function to indicate success or failure.
+///
+/// A [Result] is either an [Ok] with a value of type [T]
+/// or an [Error] with an [Exception].
+///
+/// Use [Result.ok] to create a successful result with a value of type [T].
+/// Use [Result.error] to create an error result with an [Exception].
+sealed class Result<T> extends CustomEquatable {
+  const Result();
+
+  /// Creates an instance of Result containing a value.
+  factory Result.ok(final T value) => Ok(value);
+
+  /// Create an instance of Result containing an error.
+  factory Result.error(final ExceptionState<T> error) => Error(error);
+}
+
+/// Subclass of Result for values.
+final class Ok<T> extends Result<T> {
+  const Ok(this.value);
+
+  /// Returned value in result.
+  final T value;
+
+  @override
+  Map<String, Object?> get namedProps => {'value': value};
+}
+
+/// Subclass of Result for errors.
+final class Error<T> extends Result<T> {
+  const Error(this.error);
+
+  /// Returned error in result.
+  final ExceptionState<T> error;
+
+  @override
+  Map<String, Object?> get namedProps => {'error': error};
 }

--- a/lib/src/utils/custom_equatable.dart
+++ b/lib/src/utils/custom_equatable.dart
@@ -14,8 +14,8 @@ abstract class CustomEquatable extends Equatable {
 
   @override
   String toString() {
-    final String type = runtimeType.toString();
-    final String propList = namedProps.entries
+    final type = runtimeType.toString();
+    final propList = namedProps.entries
         .map(
           (final MapEntry<String, Object?> e) => (e.value is num ||
                   e.value is Exception ||

--- a/lib/src/utils/custom_equatable.dart
+++ b/lib/src/utils/custom_equatable.dart
@@ -6,6 +6,44 @@ import 'package:equatable/equatable.dart';
 
 import '../exception_state/exception_state.dart';
 
+/// An abstract base class that extends [Equatable] to provide custom equality comparison
+/// and string representation for objects.
+///
+/// This class simplifies the implementation of equatable objects by automatically
+/// handling property comparison and string formatting based on named properties.
+///
+/// ## Usage
+/// ```dart
+/// class Person extends CustomEquatable {
+///   final String name;
+///   final int age;
+///
+///   const Person({required this.name, required this.age});
+///
+///   @override
+///   Map<String, Object?> get namedProps => {
+///     'name': name,
+///     'age': age,
+///   };
+/// }
+/// ```
+///
+/// The class provides:
+/// * Automatic equality comparison through [props]
+/// * Formatted string representation through [toString]
+/// * Type-aware property formatting
+///
+/// ## Properties
+/// * [props] - Returns a list of object properties for equality comparison
+/// * [namedProps] - Abstract getter that must be implemented by subclasses to provide
+///   a map of property names and values
+///
+/// ## Methods
+/// * [toString] - Provides a formatted string representation of the object
+/// * [_formatProperty] - Internal method to format individual properties based on their type
+///
+/// Note: Special handling is provided for numeric types, exceptions, enums, and custom
+/// exception types (DataException, ExceptionState) to format them without quotes.
 abstract class CustomEquatable extends Equatable {
   const CustomEquatable();
 
@@ -16,21 +54,34 @@ abstract class CustomEquatable extends Equatable {
   String toString() {
     final type = runtimeType.toString();
     final propList = namedProps.entries
-        .map(
-          (final MapEntry<String, Object?> e) => (e.value is num ||
-                  e.value is Exception ||
-                  e.value is Enum ||
-                  // For internal exception handler.
-                  e.value is ExceptionState ||
-                  e.value == null)
-              ? '${e.key}: ${e.value}'
-              : e.value != null && e.value != ''
-                  ? '${e.key}: "${e.value}"'
-                  : '',
-        )
+        .map(_formatProperty)
+        .where((final s) => s.isNotEmpty)
         .join(', ');
 
     return '$type($propList)'.replaceAll('], )', '])');
+  }
+
+  /// Formats a single property entry based on its type and value
+  String _formatProperty(final MapEntry<String, Object?> entry) {
+    final key = entry.key;
+    final value = entry.value;
+
+    if (value == null) {
+      return '$key: null';
+    }
+
+    // Handle special types that don't need quotes
+    if (value is num ||
+        value is Exception ||
+        value is Enum ||
+        // For internal exception handler.
+        value is DataException ||
+        value is ExceptionState) {
+      return '$key: $value';
+    }
+
+    // All other non-null values get quoted
+    return '$key: "$value"';
   }
 
   Map<String, Object?> get namedProps;

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -57,7 +57,7 @@ class UserModel {
   final String? website;
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = <String, dynamic>{};
+    final data = <String, dynamic>{};
     data['id'] = id;
     data['name'] = name;
     data['username'] = username;

--- a/test/src/exception_handler/dio/dio_http_response_extension_test.dart
+++ b/test/src/exception_handler/dio/dio_http_response_extension_test.dart
@@ -60,7 +60,7 @@ void main() {
 
     group('fromJson', () {
       test(
-        'should return SuccessState<UserModel> when conversion is successful',
+        'should return Ok<UserModel> when conversion is successful',
         () async {
           // Arrange
           final dioResponse = Response<Map<String, Object?>>(
@@ -74,16 +74,16 @@ void main() {
               await Future.value(dioResponse).fromJson(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<SuccessState<UserModel>>());
+          expect(result, isA<Ok<UserModel>>());
           expect(
-            (result as SuccessState<UserModel>).data,
+            (result as Ok<UserModel>).value,
             isA<UserModel>(),
           );
         },
       );
 
       test(
-        'should return FailureState DataParseExceptionState when conversion fails',
+        'should return Error DataParseExceptionState when conversion fails',
         () async {
           // Arrange
           final dioResponse = Response<Map<String, Object?>>(
@@ -97,20 +97,20 @@ void main() {
               await Future.value(dioResponse).fromJson(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<UserModel>>());
+          expect(result, isA<Error<UserModel>>());
           expect(
-            (result as FailureState<UserModel>).exception,
+            (result as Error<UserModel>).error,
             isA<DataParseExceptionState<Object?>>(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataParseExceptionState<UserModel>(parseException: "type \'String\' is not a subtype of type \'int\' in type cast")',
           );
         },
       );
 
       test(
-        'should return FailureState DataNetworkExceptionState.NetworkException.connectionTimeout on DioExceptionType.connectionTimeout',
+        'should return Error DataNetworkExceptionState.NetworkException.connectionTimeout on DioExceptionType.connectionTimeout',
         () async {
           // Arrange
           final dioResponse =
@@ -120,20 +120,20 @@ void main() {
           final result = await dioResponse.fromJson(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<UserModel>>());
+          expect(result, isA<Error<UserModel>>());
           expect(
-            (result as FailureState<UserModel>).exception,
+            (result as Error<UserModel>).error,
             isA<DataNetworkExceptionState<Object?>>(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataNetworkExceptionState<UserModel>(networkException: "NetworkException.timeOutException")',
           );
         },
       );
 
       test(
-        'should return FailureState DataNetworkExceptionState.NetworkException.sendTimeout on DioExceptionType.sendTimeout',
+        'should return Error DataNetworkExceptionState.NetworkException.sendTimeout on DioExceptionType.sendTimeout',
         () async {
           // Arrange
           final dioResponse = futureDioException(DioExceptionType.sendTimeout);
@@ -142,20 +142,20 @@ void main() {
           final result = await dioResponse.fromJson(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<UserModel>>());
+          expect(result, isA<Error<UserModel>>());
           expect(
-            (result as FailureState<UserModel>).exception,
+            (result as Error<UserModel>).error,
             isA<DataNetworkExceptionState<Object?>>(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataNetworkExceptionState<UserModel>(networkException: "NetworkException.sendTimeout")',
           );
         },
       );
 
       test(
-        'should return FailureState DataNetworkExceptionState.NetworkException.requestCancel on DioExceptionType.cancel',
+        'should return Error DataNetworkExceptionState.NetworkException.requestCancel on DioExceptionType.cancel',
         () async {
           // Arrange
           final dioResponse = futureDioException(DioExceptionType.cancel);
@@ -164,20 +164,20 @@ void main() {
           final result = await dioResponse.fromJson(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<UserModel>>());
+          expect(result, isA<Error<UserModel>>());
           expect(
-            (result as FailureState<UserModel>).exception,
+            (result as Error<UserModel>).error,
             isA<DataNetworkExceptionState<Object?>>(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataNetworkExceptionState<UserModel>(networkException: "NetworkException.cancel")',
           );
         },
       );
 
       test(
-        'should return FailureState DataNetworkExceptionState.NetworkException.receiveTimeout on DioExceptionType.receiveTimeout',
+        'should return Error DataNetworkExceptionState.NetworkException.receiveTimeout on DioExceptionType.receiveTimeout',
         () async {
           // Arrange
           final dioResponse =
@@ -187,20 +187,20 @@ void main() {
           final result = await dioResponse.fromJson(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<UserModel>>());
+          expect(result, isA<Error<UserModel>>());
           expect(
-            (result as FailureState<UserModel>).exception,
+            (result as Error<UserModel>).error,
             isA<DataNetworkExceptionState<Object?>>(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataNetworkExceptionState<UserModel>(networkException: "NetworkException.receiveTimeout")',
           );
         },
       );
 
       test(
-        'should return FailureState DataNetworkExceptionState.NetworkException.noInternetConnection on DioExceptionType.connectionError',
+        'should return Error DataNetworkExceptionState.NetworkException.noInternetConnection on DioExceptionType.connectionError',
         () async {
           // Arrange
           final dioResponse =
@@ -210,20 +210,20 @@ void main() {
           final result = await dioResponse.fromJson(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<UserModel>>());
+          expect(result, isA<Error<UserModel>>());
           expect(
-            (result as FailureState<UserModel>).exception,
+            (result as Error<UserModel>).error,
             isA<DataNetworkExceptionState<Object?>>(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataNetworkExceptionState<UserModel>(networkException: "NetworkException.noInternetConnection")',
           );
         },
       );
 
       test(
-        'should return FailureState DataNetworkExceptionState.NetworkException.unknown on DioExceptionType.unknown',
+        'should return Error DataNetworkExceptionState.NetworkException.unknown on DioExceptionType.unknown',
         () async {
           // Arrange
           final dioResponse = futureDioException(DioExceptionType.unknown);
@@ -232,13 +232,13 @@ void main() {
           final result = await dioResponse.fromJson(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<UserModel>>());
+          expect(result, isA<Error<UserModel>>());
           expect(
-            (result as FailureState<UserModel>).exception,
+            (result as Error<UserModel>).error,
             isA<DataHttpExceptionState<Object?>>(),
           );
           expect(
-            (result.exception as DataHttpExceptionState).httpException,
+            (result.error as DataHttpExceptionState).httpException,
             HttpException(
               httpStatus: HttpStatus(
                 code: 0,
@@ -249,14 +249,14 @@ void main() {
             ),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataHttpExceptionState<UserModel>(httpException: HttpException [0 unknown_HttpStatus]: exception: Invalid argument (code): Unrecognized status code. Use the HttpStatus constructor for custom codes: 0, message: "DioException [unknown]: null")',
           );
         },
       );
 
       test(
-        'should return FailureState.DataHttpExceptionState.httpException on DioExceptionType.badResponse with status code null',
+        'should return Error.DataHttpExceptionState.httpException on DioExceptionType.badResponse with status code null',
         () async {
           // Arrange
           final dioResponse = futureDioException(
@@ -273,13 +273,13 @@ void main() {
           final result = await dioResponse.fromJson(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<UserModel>>());
+          expect(result, isA<Error<UserModel>>());
           expect(
-            (result as FailureState<UserModel>).exception,
+            (result as Error<UserModel>).error,
             isA<DataHttpExceptionState<Object?>>(),
           );
           expect(
-            (result.exception as DataHttpExceptionState).httpException,
+            (result.error as DataHttpExceptionState).httpException,
             HttpException(
               httpStatus: HttpStatus(
                 code: 0,
@@ -290,14 +290,14 @@ void main() {
             ),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataHttpExceptionState<UserModel>(httpException: HttpException [0 unknown_HttpStatus]: exception: Invalid argument (code): Unrecognized status code. Use the HttpStatus constructor for custom codes: 0, message: "DioException [bad response]: null")',
           );
         },
       );
 
       test(
-        'should return FailureState.DataHttpExceptionState.httpException on status code 100',
+        'should return Error.DataHttpExceptionState.httpException on status code 100',
         () async {
           // Arrange
           final dioResponse = futureDioException(
@@ -314,24 +314,24 @@ void main() {
           final result = await dioResponse.fromJson(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<UserModel>>());
+          expect(result, isA<Error<UserModel>>());
           expect(
-            (result as FailureState<UserModel>).exception,
+            (result as Error<UserModel>).error,
             isA<DataHttpExceptionState<Object?>>(),
           );
           expect(
-            (result.exception as DataHttpExceptionState).httpException,
+            (result.error as DataHttpExceptionState).httpException,
             HttpStatus.fromCode(100).exception(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataHttpExceptionState<UserModel>(httpException: HttpException [100 Continue], message: "DioException [bad response]: null")',
           );
         },
       );
 
       test(
-        'should return FailureState.DataHttpExceptionState.httpException.multipleChoices on status code 300',
+        'should return Error.DataHttpExceptionState.httpException.multipleChoices on status code 300',
         () async {
           // Arrange
 
@@ -349,24 +349,24 @@ void main() {
           final result = await dioResponse.fromJson(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<UserModel>>());
+          expect(result, isA<Error<UserModel>>());
           expect(
-            (result as FailureState<UserModel>).exception,
+            (result as Error<UserModel>).error,
             isA<DataHttpExceptionState<Object?>>(),
           );
 
           expect(
-            (result.exception as DataHttpExceptionState).httpException,
+            (result.error as DataHttpExceptionState).httpException,
             HttpStatus.fromCode(300).exception(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataHttpExceptionState<UserModel>(httpException: HttpException [300 Multiple Choices], message: "DioException [bad response]: null")',
           );
         },
       );
       test(
-        'should return FailureState.DataHttpExceptionState.httpException.badRequest on status code 400',
+        'should return Error.DataHttpExceptionState.httpException.badRequest on status code 400',
         () async {
           // Arrange
           final dioResponse = futureDioException(
@@ -383,25 +383,25 @@ void main() {
           final result = await dioResponse.fromJson(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<UserModel>>());
+          expect(result, isA<Error<UserModel>>());
           expect(
-            (result as FailureState<UserModel>).exception,
+            (result as Error<UserModel>).error,
             isA<DataHttpExceptionState<Object?>>(),
           );
 
           expect(
-            (result.exception as DataHttpExceptionState).httpException,
+            (result.error as DataHttpExceptionState).httpException,
             HttpStatus.fromCode(400).exception(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataHttpExceptionState<UserModel>(httpException: HttpException [400 Bad Request], message: "DioException [bad response]: null")',
           );
         },
       );
 
       test(
-        'should return FailureState.DataHttpExceptionState.httpException.internalServerError on status code 500',
+        'should return Error.DataHttpExceptionState.httpException.internalServerError on status code 500',
         () async {
           // Arrange
           final dioResponse = futureDioException(
@@ -418,17 +418,17 @@ void main() {
           final result = await dioResponse.fromJson(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<UserModel>>());
+          expect(result, isA<Error<UserModel>>());
           expect(
-            (result as FailureState<UserModel>).exception,
+            (result as Error<UserModel>).error,
             isA<DataHttpExceptionState<Object?>>(),
           );
           expect(
-            (result.exception as DataHttpExceptionState).httpException,
+            (result.error as DataHttpExceptionState).httpException,
             HttpStatus.fromCode(500).exception(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataHttpExceptionState<UserModel>(httpException: HttpException [500 Internal Server Error], message: "DioException [bad response]: null")',
           );
         },
@@ -437,7 +437,7 @@ void main() {
 
     group('fromJsonAsList', () {
       test(
-        'should return SuccessState<List<UserModel>> when conversion is successful',
+        'should return Ok<List<UserModel>> when conversion is successful',
         () async {
           // Arrange
 
@@ -452,17 +452,17 @@ void main() {
               .fromJsonAsList(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<SuccessState<List<UserModel>>>());
+          expect(result, isA<Ok<List<UserModel>>>());
           expect(
-            (result as SuccessState<List<UserModel>>).data,
+            (result as Ok<List<UserModel>>).value,
             isA<List<UserModel>>(),
           );
-          expect(result.data.length, 2);
+          expect(result.value.length, 2);
         },
       );
 
       test(
-        'should return FailureState DataParseExceptionState when conversion fails for at least one field',
+        'should return Error DataParseExceptionState when conversion fails for at least one field',
         () async {
           // Arrange
           final dioResponse = Response<List<Object?>>(
@@ -479,20 +479,20 @@ void main() {
               .fromJsonAsList(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<List<UserModel>>>());
+          expect(result, isA<Error<List<UserModel>>>());
           expect(
-            (result as FailureState<List<UserModel>>).exception,
+            (result as Error<List<UserModel>>).error,
             isA<DataParseExceptionState<Object?>>(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataParseExceptionState<List<UserModel>>(parseException: "type \'List<Object?>\' is not a subtype of type \'List<Map<String, dynamic>>\' in type cast")',
           );
         },
       );
 
       test(
-        'should return FailureState DataNetworkExceptionState.NetworkException.connectionTimeout on DioExceptionType.connectionTimeout',
+        'should return Error DataNetworkExceptionState.NetworkException.connectionTimeout on DioExceptionType.connectionTimeout',
         () async {
           // Arrange
           final dioResponse =
@@ -502,20 +502,20 @@ void main() {
           final result = await dioResponse.fromJsonAsList(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<List<UserModel>>>());
+          expect(result, isA<Error<List<UserModel>>>());
           expect(
-            (result as FailureState<List<UserModel>>).exception,
+            (result as Error<List<UserModel>>).error,
             isA<DataNetworkExceptionState<Object?>>(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataNetworkExceptionState<List<UserModel>>(networkException: "NetworkException.timeOutException")',
           );
         },
       );
 
       test(
-        'should return FailureState DataNetworkExceptionState.NetworkException.sendTimeout on DioExceptionType.sendTimeout',
+        'should return Error DataNetworkExceptionState.NetworkException.sendTimeout on DioExceptionType.sendTimeout',
         () async {
           // Arrange
           final dioResponse = futureDioException(DioExceptionType.sendTimeout);
@@ -525,22 +525,22 @@ void main() {
 
           // Assert
           expect(
-            result as FailureState<List<UserModel>>,
-            isA<FailureState<List<UserModel>>>(),
+            result as Error<List<UserModel>>,
+            isA<Error<List<UserModel>>>(),
           );
           expect(
-            result.exception,
+            result.error,
             isA<DataNetworkExceptionState<Object?>>(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataNetworkExceptionState<List<UserModel>>(networkException: "NetworkException.sendTimeout")',
           );
         },
       );
 
       test(
-        'should return FailureState DataNetworkExceptionState.NetworkException.requestCancel on DioExceptionType.cancel',
+        'should return Error DataNetworkExceptionState.NetworkException.requestCancel on DioExceptionType.cancel',
         () async {
           // Arrange
           final dioResponse = futureDioException(DioExceptionType.cancel);
@@ -549,20 +549,20 @@ void main() {
           final result = await dioResponse.fromJsonAsList(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<List<UserModel>>>());
+          expect(result, isA<Error<List<UserModel>>>());
           expect(
-            (result as FailureState<List<UserModel>>).exception,
+            (result as Error<List<UserModel>>).error,
             isA<DataNetworkExceptionState<Object?>>(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataNetworkExceptionState<List<UserModel>>(networkException: "NetworkException.cancel")',
           );
         },
       );
 
       test(
-        'should return FailureState DataNetworkExceptionState.NetworkException.receiveTimeout on DioExceptionType.receiveTimeout',
+        'should return Error DataNetworkExceptionState.NetworkException.receiveTimeout on DioExceptionType.receiveTimeout',
         () async {
           // Arrange
           final dioResponse =
@@ -572,20 +572,20 @@ void main() {
           final result = await dioResponse.fromJsonAsList(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<List<UserModel>>>());
+          expect(result, isA<Error<List<UserModel>>>());
           expect(
-            (result as FailureState<List<UserModel>>).exception,
+            (result as Error<List<UserModel>>).error,
             isA<DataNetworkExceptionState<Object?>>(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataNetworkExceptionState<List<UserModel>>(networkException: "NetworkException.receiveTimeout")',
           );
         },
       );
 
       test(
-        'should return FailureState DataNetworkExceptionState.NetworkException.noInternetConnection on DioExceptionType.connectionError',
+        'should return Error DataNetworkExceptionState.NetworkException.noInternetConnection on DioExceptionType.connectionError',
         () async {
           // Arrange
           final dioResponse =
@@ -595,20 +595,20 @@ void main() {
           final result = await dioResponse.fromJsonAsList(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<List<UserModel>>>());
+          expect(result, isA<Error<List<UserModel>>>());
           expect(
-            (result as FailureState<List<UserModel>>).exception,
+            (result as Error<List<UserModel>>).error,
             isA<DataNetworkExceptionState<Object?>>(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataNetworkExceptionState<List<UserModel>>(networkException: "NetworkException.noInternetConnection")',
           );
         },
       );
 
       test(
-        'should return FailureState DataNetworkExceptionState.NetworkException.unknown on DioExceptionType.unknown',
+        'should return Error DataNetworkExceptionState.NetworkException.unknown on DioExceptionType.unknown',
         () async {
           // Arrange
           final dioResponse = futureDioException(DioExceptionType.unknown);
@@ -617,13 +617,13 @@ void main() {
           final result = await dioResponse.fromJsonAsList(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<List<UserModel>>>());
+          expect(result, isA<Error<List<UserModel>>>());
           expect(
-            (result as FailureState<List<UserModel>>).exception,
+            (result as Error<List<UserModel>>).error,
             isA<DataHttpExceptionState<Object?>>(),
           );
           expect(
-            (result.exception as DataHttpExceptionState).httpException,
+            (result.error as DataHttpExceptionState).httpException,
             HttpException(
               httpStatus: HttpStatus(
                 code: 0,
@@ -634,14 +634,14 @@ void main() {
             ),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataHttpExceptionState<List<UserModel>>(httpException: HttpException [0 unknown_HttpStatus]: exception: Invalid argument (code): Unrecognized status code. Use the HttpStatus constructor for custom codes: 0, message: "DioException [unknown]: null")',
           );
         },
       );
 
       test(
-        'should return FailureState.DataHttpExceptionState.httpException on DioExceptionType.badResponse with status code null',
+        'should return Error.DataHttpExceptionState.httpException on DioExceptionType.badResponse with status code null',
         () async {
           // Arrange
           final dioResponse = futureDioException(
@@ -658,13 +658,13 @@ void main() {
           final result = await dioResponse.fromJsonAsList(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<List<UserModel>>>());
+          expect(result, isA<Error<List<UserModel>>>());
           expect(
-            (result as FailureState<List<UserModel>>).exception,
+            (result as Error<List<UserModel>>).error,
             isA<DataHttpExceptionState<Object?>>(),
           );
           expect(
-            (result.exception as DataHttpExceptionState).httpException,
+            (result.error as DataHttpExceptionState).httpException,
             HttpException(
               httpStatus: HttpStatus(
                 code: 0,
@@ -675,14 +675,14 @@ void main() {
             ),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataHttpExceptionState<List<UserModel>>(httpException: HttpException [0 unknown_HttpStatus]: exception: Invalid argument (code): Unrecognized status code. Use the HttpStatus constructor for custom codes: 0, message: "DioException [bad response]: null")',
           );
         },
       );
 
       test(
-        'should return FailureState<HttpFailure.informationalResponse> on status code 100',
+        'should return Error<HttpFailure.informationalResponse> on status code 100',
         () async {
           // Arrange
           final dioResponse = futureDioException(
@@ -699,24 +699,24 @@ void main() {
           final result = await dioResponse.fromJsonAsList(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<List<UserModel>>>());
+          expect(result, isA<Error<List<UserModel>>>());
           expect(
-            (result as FailureState<List<UserModel>>).exception,
+            (result as Error<List<UserModel>>).error,
             isA<DataHttpExceptionState<Object?>>(),
           );
           expect(
-            (result.exception as DataHttpExceptionState).httpException,
+            (result.error as DataHttpExceptionState).httpException,
             HttpStatus.fromCode(100).exception(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataHttpExceptionState<List<UserModel>>(httpException: HttpException [100 Continue], message: "DioException [bad response]: null")',
           );
         },
       );
 
       test(
-        'should return FailureState.DataHttpExceptionState.httpException.unknownRedirect on status code 300',
+        'should return Error.DataHttpExceptionState.httpException.unknownRedirect on status code 300',
         () async {
           // Arrange
           final dioResponse = futureDioException(
@@ -733,24 +733,24 @@ void main() {
           final result = await dioResponse.fromJsonAsList(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<List<UserModel>>>());
+          expect(result, isA<Error<List<UserModel>>>());
           expect(
-            (result as FailureState<List<UserModel>>).exception,
+            (result as Error<List<UserModel>>).error,
             isA<DataHttpExceptionState<Object?>>(),
           );
           expect(
-            (result.exception as DataHttpExceptionState).httpException,
+            (result.error as DataHttpExceptionState).httpException,
             HttpStatus.fromCode(300).exception(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataHttpExceptionState<List<UserModel>>(httpException: HttpException [300 Multiple Choices], message: "DioException [bad response]: null")',
           );
         },
       );
 
       test(
-        'should return FailureState.DataHttpExceptionState.httpException.unknownClient on status code 400',
+        'should return Error.DataHttpExceptionState.httpException.unknownClient on status code 400',
         () async {
           // Arrange
           final dioResponse = futureDioException(
@@ -767,24 +767,24 @@ void main() {
           final result = await dioResponse.fromJsonAsList(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<List<UserModel>>>());
+          expect(result, isA<Error<List<UserModel>>>());
           expect(
-            (result as FailureState<List<UserModel>>).exception,
+            (result as Error<List<UserModel>>).error,
             isA<DataHttpExceptionState<Object?>>(),
           );
           expect(
-            (result.exception as DataHttpExceptionState).httpException,
+            (result.error as DataHttpExceptionState).httpException,
             HttpStatus.fromCode(400).exception(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataHttpExceptionState<List<UserModel>>(httpException: HttpException [400 Bad Request], message: "DioException [bad response]: null")',
           );
         },
       );
 
       test(
-        'should return FailureState.DataHttpExceptionState.httpException.internalServerError on status code 500',
+        'should return Error.DataHttpExceptionState.httpException.internalServerError on status code 500',
         () async {
           // Arrange
           final dioResponse = futureDioException(
@@ -801,17 +801,17 @@ void main() {
           final result = await dioResponse.fromJsonAsList(UserModel.fromJson);
 
           // Assert
-          expect(result, isA<FailureState<List<UserModel>>>());
+          expect(result, isA<Error<List<UserModel>>>());
           expect(
-            (result as FailureState<List<UserModel>>).exception,
+            (result as Error<List<UserModel>>).error,
             isA<DataHttpExceptionState<Object?>>(),
           );
           expect(
-            (result.exception as DataHttpExceptionState).httpException,
+            (result.error as DataHttpExceptionState).httpException,
             HttpStatus.fromCode(500).exception(),
           );
           expect(
-            result.exception.toString(),
+            result.error.toString(),
             'DataHttpExceptionState<List<UserModel>>(httpException: HttpException [500 Internal Server Error], message: "DioException [bad response]: null")',
           );
         },

--- a/test/src/exception_handler/dio/exception_handler_dio_test.dart
+++ b/test/src/exception_handler/dio/exception_handler_dio_test.dart
@@ -36,7 +36,7 @@ void main() {
             ),
           );
 
-          final Result<String> result = await DioExceptionHandler.callApi_(
+          final result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (final Object? data) =>
@@ -153,7 +153,7 @@ void main() {
             ),
           );
 
-          final Result<String> result = await DioExceptionHandler.callApi_(
+          final result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (final Object? data) => int.parse(data as String)
@@ -178,7 +178,7 @@ void main() {
       test(
         'should return Error with DataHttpException for 3xx error',
         () async {
-          final Result<Object?> result = await DioExceptionHandler.callApi_(
+          final result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () async => Response<Object>(
                 requestOptions: RequestOptions(path: ''),
@@ -211,7 +211,7 @@ void main() {
               statusCode: 400,
             ),
           );
-          final Result<Object?> result = await DioExceptionHandler.callApi_(
+          final result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (final res) => null,
@@ -243,7 +243,7 @@ void main() {
               statusCode: 404,
             ),
           );
-          final Result<Object?> result = await DioExceptionHandler.callApi_(
+          final result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (final res) => null,
@@ -276,7 +276,7 @@ void main() {
               statusCode: 500,
             ),
           );
-          final Result<Object?> result = await DioExceptionHandler.callApi_(
+          final result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (final res) => null,
@@ -291,7 +291,7 @@ void main() {
               expect(error, isA<DataHttpExceptionState<Object?>>());
               if (error is DataHttpExceptionState) {
                 expect(
-                    error.httpException,
+                  error.httpException,
                   equals(HttpStatus.fromCode(500).exception()),
                 );
               }
@@ -307,7 +307,7 @@ void main() {
               statusCode: 501,
             ),
           );
-          final Result<Object?> result = await DioExceptionHandler.callApi_(
+          final result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (final res) => null,
@@ -339,7 +339,7 @@ void main() {
               statusCode: 600,
             ),
           );
-          final Result<Object?> result = await DioExceptionHandler.callApi_(
+          final result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (final res) => null,
@@ -383,8 +383,7 @@ void main() {
           when(() => mockConnectivity.checkConnectivity())
               .thenAnswer((final _) async => [ConnectivityResult.wifi]);
 
-          final Result<String> result =
-              await DioExceptionHandler.callApi_(mockApiHandler);
+          final result = await DioExceptionHandler.callApi_(mockApiHandler);
 
           expect(result, isA<Error<Object?>>());
 
@@ -413,8 +412,7 @@ void main() {
           when(() => mockConnectivity.checkConnectivity())
               .thenAnswer((final _) async => [ConnectivityResult.wifi]);
 
-          final Result<String> result =
-              await DioExceptionHandler.callApi_(mockApiHandler);
+          final result = await DioExceptionHandler.callApi_(mockApiHandler);
 
           expect(result, isA<Error<Object?>>());
 
@@ -443,8 +441,7 @@ void main() {
           when(() => mockConnectivity.checkConnectivity())
               .thenAnswer((final _) async => [ConnectivityResult.wifi]);
 
-          final Result<String> result =
-              await DioExceptionHandler.callApi_(mockApiHandler);
+          final result = await DioExceptionHandler.callApi_(mockApiHandler);
 
           expect(result, isA<Error<Object?>>());
 
@@ -498,7 +495,7 @@ void main() {
             ),
           );
 
-          final Result<String> result = await DioExceptionHandler.callApi_(
+          final result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (final Object? data) {

--- a/test/src/exception_handler/dio/exception_handler_dio_test.dart
+++ b/test/src/exception_handler/dio/exception_handler_dio_test.dart
@@ -36,7 +36,7 @@ void main() {
             ),
           );
 
-          final ResultState<String> result = await DioExceptionHandler.callApi_(
+          final Result<String> result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (final Object? data) =>
@@ -47,10 +47,10 @@ void main() {
           String? success;
           ExceptionState<String>? failure;
           switch (result) {
-            case SuccessState<String>(:final String data):
-              success = data;
-            case FailureState<String>(:final ExceptionState<String> exception):
-              failure = exception;
+            case Ok<String>(:final String value):
+              success = value;
+            case Error<String>(:final ExceptionState<String> error):
+              failure = error;
           }
 
           expect(failure, isNull);
@@ -78,10 +78,10 @@ void main() {
           String? success;
           ExceptionState<String>? failure;
           switch (result) {
-            case SuccessState<String>(:final String data):
-              success = data;
-            case FailureState<String>(:final ExceptionState<String> exception):
-              failure = exception;
+            case Ok<String>(:final String value):
+              success = value;
+            case Error<String>(:final ExceptionState<String> error):
+              failure = error;
           }
 
           expect(success, isNull);
@@ -104,13 +104,13 @@ void main() {
 
           final result = await DioExceptionHandler.callApi_(mockApiHandler);
 
-          expect(result, isA<FailureState<Object?>>());
+          expect(result, isA<Error<Object?>>());
 
           switch (result) {
-            case SuccessState<String>():
+            case Ok<String>():
               fail('Expected failure but got success');
-            case FailureState<String>(:final ExceptionState<String> exception):
-              expect(exception, isA<DataNetworkExceptionState<Object?>>());
+            case Error<String>(:final ExceptionState<String> error):
+              expect(error, isA<DataNetworkExceptionState<Object?>>());
           }
         },
       );
@@ -131,10 +131,10 @@ void main() {
           ExceptionState<String>? failure;
 
           switch (result) {
-            case SuccessState<String>(:final String data):
-              success = data;
-            case FailureState<String>(:final ExceptionState<String> exception):
-              failure = exception;
+            case Ok<String>(:final String value):
+              success = value;
+            case Error<String>(:final ExceptionState<String> error):
+              failure = error;
           }
 
           expect(success, isNull);
@@ -153,7 +153,7 @@ void main() {
             ),
           );
 
-          final ResultState<String> result = await DioExceptionHandler.callApi_(
+          final Result<String> result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (final Object? data) => int.parse(data as String)
@@ -164,10 +164,10 @@ void main() {
           String? success;
           ExceptionState<String>? failure;
           switch (result) {
-            case SuccessState<String>(:final String data):
-              success = data;
-            case FailureState<String>(:final ExceptionState<String> exception):
-              failure = exception;
+            case Ok<String>(:final String value):
+              success = value;
+            case Error<String>(:final ExceptionState<String> error):
+              failure = error;
           }
 
           expect(success, isNull);
@@ -176,10 +176,9 @@ void main() {
       );
 
       test(
-        'should return FailureState with DataHttpException for 3xx error',
+        'should return Error with DataHttpException for 3xx error',
         () async {
-          final ResultState<Object?> result =
-              await DioExceptionHandler.callApi_(
+          final Result<Object?> result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () async => Response<Object>(
                 requestOptions: RequestOptions(path: ''),
@@ -189,22 +188,22 @@ void main() {
             ),
           );
 
-          expect(result, isA<FailureState<Object?>>());
+          expect(result, isA<Error<Object?>>());
 
           switch (result) {
-            case SuccessState():
+            case Ok():
               fail('Expected failure but got success');
-            case FailureState(:final ExceptionState<Object?> exception):
-              expect(exception, isA<DataHttpExceptionState<Object?>>());
+            case Error(:final ExceptionState<Object?> error):
+              expect(error, isA<DataHttpExceptionState<Object?>>());
               expect(
-                (exception as DataHttpExceptionState).httpException,
+                (error as DataHttpExceptionState).httpException,
                 equals(HttpStatus.fromCode(300).exception()),
               );
           }
         },
       );
       test(
-        'should return FailureState with DataHttpException for 4xx error',
+        'should return Error with DataHttpException for 4xx error',
         () async {
           when(() => mockDio.get<Object>(any())).thenAnswer(
             (final _) async => Response(
@@ -212,24 +211,23 @@ void main() {
               statusCode: 400,
             ),
           );
-          final ResultState<Object?> result =
-              await DioExceptionHandler.callApi_(
+          final Result<Object?> result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (final res) => null,
             ),
           );
 
-          expect(result, isA<FailureState<Object?>>());
+          expect(result, isA<Error<Object?>>());
 
           switch (result) {
-            case SuccessState():
+            case Ok():
               fail('Expected failure but got success');
-            case FailureState(:final ExceptionState<Object?> exception):
-              expect(exception, isA<DataHttpExceptionState<Object?>>());
-              if (exception is DataHttpExceptionState) {
+            case Error(:final ExceptionState<Object?> error):
+              expect(error, isA<DataHttpExceptionState<Object?>>());
+              if (error is DataHttpExceptionState) {
                 expect(
-                  exception.httpException,
+                  error.httpException,
                   equals(HttpStatus.fromCode(400).exception()),
                 );
               }
@@ -237,7 +235,7 @@ void main() {
         },
       );
       test(
-        'should return FailureState with DataHttpException for 404 error',
+        'should return Error with DataHttpException for 404 error',
         () async {
           when(() => mockDio.get<Object>(any())).thenAnswer(
             (final _) async => Response(
@@ -245,24 +243,23 @@ void main() {
               statusCode: 404,
             ),
           );
-          final ResultState<Object?> result =
-              await DioExceptionHandler.callApi_(
+          final Result<Object?> result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (final res) => null,
             ),
           );
 
-          expect(result, isA<FailureState<Object?>>());
+          expect(result, isA<Error<Object?>>());
 
           switch (result) {
-            case SuccessState():
+            case Ok():
               fail('Expected failure but got success');
-            case FailureState(:final ExceptionState<Object?> exception):
-              expect(exception, isA<DataHttpExceptionState<Object?>>());
-              if (exception is DataHttpExceptionState) {
+            case Error(:final ExceptionState<Object?> error):
+              expect(error, isA<DataHttpExceptionState<Object?>>());
+              if (error is DataHttpExceptionState) {
                 expect(
-                  exception.httpException,
+                  error.httpException,
                   equals(HttpStatus.fromCode(404).exception()),
                 );
               }
@@ -271,7 +268,7 @@ void main() {
       );
 
       test(
-        'should return FailureState with DataHttpException for 500 error',
+        'should return Error with DataHttpException for 500 error',
         () async {
           when(() => mockDio.get<Object>(any())).thenAnswer(
             (final _) async => Response(
@@ -279,23 +276,22 @@ void main() {
               statusCode: 500,
             ),
           );
-          final ResultState<Object?> result =
-              await DioExceptionHandler.callApi_(
+          final Result<Object?> result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (final res) => null,
             ),
           );
-          expect(result, isA<FailureState<Object?>>());
+          expect(result, isA<Error<Object?>>());
 
           switch (result) {
-            case SuccessState():
+            case Ok():
               fail('Expected failure but got success');
-            case FailureState(:final ExceptionState<Object?> exception):
-              expect(exception, isA<DataHttpExceptionState<Object?>>());
-              if (exception is DataHttpExceptionState) {
+            case Error(:final ExceptionState<Object?> error):
+              expect(error, isA<DataHttpExceptionState<Object?>>());
+              if (error is DataHttpExceptionState) {
                 expect(
-                  exception.httpException,
+                    error.httpException,
                   equals(HttpStatus.fromCode(500).exception()),
                 );
               }
@@ -303,7 +299,7 @@ void main() {
         },
       );
       test(
-        'should return FailureState with DataHttpException for 501 error',
+        'should return Error with DataHttpException for 501 error',
         () async {
           when(() => mockDio.get<Object>(any())).thenAnswer(
             (final _) async => Response(
@@ -311,24 +307,23 @@ void main() {
               statusCode: 501,
             ),
           );
-          final ResultState<Object?> result =
-              await DioExceptionHandler.callApi_(
+          final Result<Object?> result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (final res) => null,
             ),
           );
 
-          expect(result, isA<FailureState<Object?>>());
+          expect(result, isA<Error<Object?>>());
 
           switch (result) {
-            case SuccessState():
+            case Ok():
               fail('Expected failure but got success');
-            case FailureState(:final ExceptionState<Object?> exception):
-              expect(exception, isA<DataHttpExceptionState<Object?>>());
-              if (exception is DataHttpExceptionState) {
+            case Error(:final ExceptionState<Object?> error):
+              expect(error, isA<DataHttpExceptionState<Object?>>());
+              if (error is DataHttpExceptionState) {
                 expect(
-                  exception.httpException,
+                  error.httpException,
                   equals(HttpStatus.fromCode(501).exception()),
                 );
               }
@@ -336,7 +331,7 @@ void main() {
         },
       );
       test(
-        'should return FailureState with DataHttpException for 600 error',
+        'should return Error with DataHttpException for 600 error',
         () async {
           when(() => mockDio.get<Object>(any())).thenAnswer(
             (final _) async => Response(
@@ -344,24 +339,23 @@ void main() {
               statusCode: 600,
             ),
           );
-          final ResultState<Object?> result =
-              await DioExceptionHandler.callApi_(
+          final Result<Object?> result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (final res) => null,
             ),
           );
 
-          expect(result, isA<FailureState<Object?>>());
+          expect(result, isA<Error<Object?>>());
 
           switch (result) {
-            case SuccessState():
+            case Ok():
               fail('Expected failure but got success');
-            case FailureState(:final ExceptionState<Object?> exception):
-              expect(exception, isA<DataHttpExceptionState<Object?>>());
-              if (exception is DataHttpExceptionState) {
+            case Error(:final ExceptionState<Object?> error):
+              expect(error, isA<DataHttpExceptionState<Object?>>());
+              if (error is DataHttpExceptionState) {
                 expect(
-                  exception.httpException,
+                  error.httpException,
                   equals(
                     HttpException(
                       httpStatus: HttpStatus(
@@ -389,24 +383,24 @@ void main() {
           when(() => mockConnectivity.checkConnectivity())
               .thenAnswer((final _) async => [ConnectivityResult.wifi]);
 
-          final ResultState<String> result =
+          final Result<String> result =
               await DioExceptionHandler.callApi_(mockApiHandler);
 
-          expect(result, isA<FailureState<Object?>>());
+          expect(result, isA<Error<Object?>>());
 
           switch (result) {
-            case SuccessState():
+            case Ok():
               fail('Expected failure but got success');
-            case FailureState(:final ExceptionState<Object?> exception):
-              expect(exception, isA<DataNetworkExceptionState<Object?>>());
-              if (exception is DataNetworkExceptionState) {
+            case Error(:final ExceptionState<Object?> error):
+              expect(error, isA<DataNetworkExceptionState<Object?>>());
+              if (error is DataNetworkExceptionState) {
                 expect(
-                  exception.message,
+                  error.message,
                   equals('NetworkException.timeOutException'),
                 );
               }
           }
-          expect(result.exception, isA<DataNetworkExceptionState<Object?>>());
+          expect(result.error, isA<DataNetworkExceptionState<Object?>>());
         },
       );
       test(
@@ -419,24 +413,24 @@ void main() {
           when(() => mockConnectivity.checkConnectivity())
               .thenAnswer((final _) async => [ConnectivityResult.wifi]);
 
-          final ResultState<String> result =
+          final Result<String> result =
               await DioExceptionHandler.callApi_(mockApiHandler);
 
-          expect(result, isA<FailureState<Object?>>());
+          expect(result, isA<Error<Object?>>());
 
           switch (result) {
-            case SuccessState():
+            case Ok():
               fail('Expected failure but got success');
-            case FailureState(:final ExceptionState<Object?> exception):
-              expect(exception, isA<DataNetworkExceptionState<Object?>>());
-              if (exception is DataNetworkExceptionState) {
+            case Error(:final ExceptionState<Object?> error):
+              expect(error, isA<DataNetworkExceptionState<Object?>>());
+              if (error is DataNetworkExceptionState) {
                 expect(
-                  exception.message,
+                  error.message,
                   equals('NetworkException.sendTimeout'),
                 );
               }
           }
-          expect(result.exception, isA<DataNetworkExceptionState<Object?>>());
+          expect(result.error, isA<DataNetworkExceptionState<Object?>>());
         },
       );
       test(
@@ -449,19 +443,19 @@ void main() {
           when(() => mockConnectivity.checkConnectivity())
               .thenAnswer((final _) async => [ConnectivityResult.wifi]);
 
-          final ResultState<String> result =
+          final Result<String> result =
               await DioExceptionHandler.callApi_(mockApiHandler);
 
-          expect(result, isA<FailureState<Object?>>());
+          expect(result, isA<Error<Object?>>());
 
           switch (result) {
-            case SuccessState():
+            case Ok():
               fail('Expected failure but got success');
-            case FailureState(:final ExceptionState<Object?> exception):
-              expect(exception, isA<DataHttpExceptionState<Object?>>());
-              if (exception is DataHttpExceptionState) {
+            case Error(:final ExceptionState<Object?> error):
+              expect(error, isA<DataHttpExceptionState<Object?>>());
+              if (error is DataHttpExceptionState) {
                 expect(
-                  exception.httpException,
+                  error.httpException,
                   equals(
                     HttpException(
                       httpStatus: HttpStatus(
@@ -475,7 +469,7 @@ void main() {
                 );
               }
           }
-          expect(result.exception, isA<DataHttpExceptionState<Object?>>());
+          expect(result.error, isA<DataHttpExceptionState<Object?>>());
         },
       );
 
@@ -486,9 +480,9 @@ void main() {
           when(() => mockApiHandler.apiCall()).thenThrow(exception);
           final result = await DioExceptionHandler.callApi_(mockApiHandler);
 
-          expect(result, isA<FailureState<Object?>>());
+          expect(result, isA<Error<Object?>>());
           expect(
-            (result as FailureState).exception,
+            (result as Error<Object?>).error,
             isA<DataClientExceptionState<Object?>>(),
           );
         },
@@ -504,7 +498,7 @@ void main() {
             ),
           );
 
-          final ResultState<String> result = await DioExceptionHandler.callApi_(
+          final Result<String> result = await DioExceptionHandler.callApi_(
             ApiHandler(
               apiCall: () => mockDio.get<Object>('test'),
               parserModel: (final Object? data) {
@@ -516,10 +510,10 @@ void main() {
           String? success;
           ExceptionState<String>? failure;
           switch (result) {
-            case SuccessState<String>(:final String data):
-              success = data;
-            case FailureState<String>(:final ExceptionState<String> exception):
-              failure = exception;
+            case Ok<String>(:final String value):
+              success = value;
+            case Error<String>(:final ExceptionState<String> error):
+              failure = error;
           }
 
           expect(success, isNull);

--- a/test/src/exception_handler/typedef_test.dart
+++ b/test/src/exception_handler/typedef_test.dart
@@ -30,7 +30,7 @@ void main() {
   group(
     'ResponseParser',
     () {
-      final Response<Object?> mockResponse = Response<Object?>(
+      final mockResponse = Response<Object?>(
         data: {'key': 'value'},
         statusCode: 200,
         requestOptions: RequestOptions(),

--- a/test/src/exception_state/exceptions_state_test.dart
+++ b/test/src/exception_state/exceptions_state_test.dart
@@ -33,8 +33,7 @@ void main() {
       'DataParseExceptionState',
       () {
         const exception = 'Parse error';
-        final DataParseExceptionState<String> dataParseException =
-            DataParseExceptionState<String>(
+        final dataParseException = DataParseExceptionState<String>(
           message: exception,
           stackTrace: StackTrace.current,
         );
@@ -53,8 +52,7 @@ void main() {
       'DataHttpExceptionState',
       () {
         group('null message', () {
-          final DataHttpExceptionState<String> dataHttpException =
-              DataHttpExceptionState<String>(
+          final dataHttpException = DataHttpExceptionState<String>(
             message: null,
             httpException: HttpStatus.fromCode(401).exception(),
             stackTrace: StackTrace.current,
@@ -73,8 +71,7 @@ void main() {
           });
         });
         group('non-null message', () {
-          final DataHttpExceptionState<String> dataHttpException =
-              DataHttpExceptionState<String>(
+          final dataHttpException = DataHttpExceptionState<String>(
             message: 'Error ABC',
             httpException: HttpStatus.fromCode(402).exception(),
             stackTrace: StackTrace.current,
@@ -97,8 +94,7 @@ void main() {
     group(
       'DataNetworkExceptionState',
       () {
-        final DataNetworkExceptionState<String> dataNetworkException =
-            DataNetworkExceptionState<String>(
+        final dataNetworkException = DataNetworkExceptionState<String>(
           message: 'NetworkException.noInternetConnection',
           stackTrace: StackTrace.current,
         );
@@ -120,8 +116,7 @@ void main() {
     group(
       'DataCacheExceptionState',
       () {
-        final DataCacheExceptionState<String> dataCacheException =
-            DataCacheExceptionState<String>(
+        final dataCacheException = DataCacheExceptionState<String>(
           message: 'CacheException.unknown',
           stackTrace: StackTrace.current,
         );
@@ -143,7 +138,7 @@ void main() {
     group(
       'DataInvalidInputExceptionState',
       () {
-        final DataInvalidInputExceptionState<String> dataInvalidInputException =
+        final dataInvalidInputException =
             DataInvalidInputExceptionState<String>(
           message: 'InvalidInputException.unknown',
           stackTrace: StackTrace.current,
@@ -166,8 +161,7 @@ void main() {
     group(
       'DataUnknownExceptionState',
       () {
-        final DataUnknownExceptionState<String> dataUnknownException =
-            DataUnknownExceptionState<String>(
+        final dataUnknownException = DataUnknownExceptionState<String>(
           message: 'UnknownException.unknown',
           stackTrace: StackTrace.current,
         );

--- a/test/src/result_state/result_state_test.dart
+++ b/test/src/result_state/result_state_test.dart
@@ -26,14 +26,13 @@ void main() {
   group(
     'Error',
     () {
-      final DataClientExceptionState<String> exception =
-          DataClientExceptionState<String>(
+      final exception = DataClientExceptionState<String>(
         message: 'Test Exception',
         stackTrace: StackTrace.current,
       );
-      final Error<String> resultState = Error<String>(exception);
+      final resultState = Error<String>(exception);
       test('should call failure callback with correct exception', () {
-        final bool failureCalled = switch (resultState) {
+        final failureCalled = switch (resultState) {
           Error() => true,
         };
 

--- a/test/src/result_state/result_state_test.dart
+++ b/test/src/result_state/result_state_test.dart
@@ -3,13 +3,13 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group(
-    'SuccessState',
+    'Ok',
     () {
       const data = 'Test Data';
-      const resultState = SuccessState<String>(data);
+      const resultState = Ok<String>(data);
       test('should call success callback with correct data', () {
         final result = switch (resultState) {
-          SuccessState<String>(:final String data) => data,
+          Ok<String>(:final String value) => value,
         };
 
         expect(result, equals(data));
@@ -17,33 +17,33 @@ void main() {
       test('should correct toString', () {
         expect(
           resultState.toString(),
-          'SuccessState<String>(data: "Test Data")',
+          'Ok<String>(value: "Test Data")',
         );
       });
     },
   );
 
   group(
-    'FailureState',
+    'Error',
     () {
       final DataClientExceptionState<String> exception =
           DataClientExceptionState<String>(
         message: 'Test Exception',
         stackTrace: StackTrace.current,
       );
-      final FailureState<String> resultState = FailureState<String>(exception);
+      final Error<String> resultState = Error<String>(exception);
       test('should call failure callback with correct exception', () {
         final bool failureCalled = switch (resultState) {
-          FailureState() => true,
+          Error() => true,
         };
 
         expect(failureCalled, isTrue);
-        expect(resultState.exception, equals(exception));
+        expect(resultState.error, equals(exception));
       });
       test('should correct toString', () {
         expect(
           resultState.toString(),
-          'FailureState<String>(exception: DataClientExceptionState<String>(clientException: "Test Exception"))',
+          'Error<String>(error: DataClientExceptionState<String>(clientException: "Test Exception"))',
         );
       });
     },


### PR DESCRIPTION
## Summary by Sourcery

Rename `SuccessState` to `Ok` and `FailureState` to `Error`.

New Features:
- Introduce the `Result` class, inspired by the Dart language documentation, for simplified error handling.

Tests:
- Update tests to reflect the renaming of `SuccessState` to `Ok` and `FailureState` to `Error`.